### PR TITLE
Make no extra Topics

### DIFF
--- a/chipy_org/apps/meetings/admin.py
+++ b/chipy_org/apps/meetings/admin.py
@@ -11,7 +11,7 @@ admin.site.register(Venue)
 
 class TopicInline(admin.StackedInline):
     model = Topic
-    extra = 1
+    extra = 0
 
 
 class TopicAdmin(admin.ModelAdmin):


### PR DESCRIPTION
I usually don't know any topics when creating a meeting. So default to 0 extra so not to get a failure when trying to save.
