### PR TITLE
Mismatches quotes breaking rsvp form

### DIFF
--- a/chipy_org/templates/_homepage.js
+++ b/chipy_org/templates/_homepage.js
@@ -7,7 +7,7 @@ $('.rsvp').click(function(){
     {% if request.user.is_authenticated %}
     $.ajax({
         type: 'POST',
-        url: "{% url 'rsvp' %}',
+        url: "{% url 'rsvp' %}",
         data: {response:$(this).data('response'), csrfmiddlewaretoken: '{{ csrf_token }}', meeting: '{{ next_meeting.id }}'},
         success: function(data){
             location.reload();


### PR DESCRIPTION
Was trying to sign up tonight and couldn't get the form to submit. Investigated a bit and found this being parsed with an exception on chrome as an illegal token.