### PR TITLE
Add sponsor logos

### DIFF
--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -83,6 +83,8 @@
               {% endif %}
             {% endif %}
             <p><a class="btn" href="{% url 'past_meetings' %}">Past meetings &raquo;</a></p>
+            <p><img src="{{ STATIC_URL }}img/braintree.png" alt="Braintree (Sponsor)"></p>
+            <p><img src="{{ STATIC_URL }}img/telnyx.png" alt="Telnyx (Sponsor)"></p>
         </div><!--/span-->
         <div class="module span4">
             <h2>This Month's Topics</h2>


### PR DESCRIPTION
This is an example to show what we need to do by the end of the month. Let's not do anything complicated until we meet our obligations to the Platinum Sponsors. Just resize the images in https://github.com/chicagopython/chipy.org/issues/98 and put them on the homepage. (The code in this commit is not real and this should not actually be merged).

@emperorcezar @JoeJasinski 