### PR TITLE
make the slides link public if added

### DIFF
--- a/chipy_org/apps/meetings/templates/meetings/_talk.html
+++ b/chipy_org/apps/meetings/templates/meetings/_talk.html
@@ -8,6 +8,7 @@
             {% endif %}
         {% endfor %}
         <div class="topic-date">Date: {% firstof talk.start_time talk.meeting.when %}</div>
+        {% if talk.slides_link %}<div><a href="{{ talk.slides_link }}">Slides Link</a></div>{% endif %}
         <div class="description">
           {{ talk.description }}
         </div>

--- a/chipy_org/templates/meetings/past_meetings.html
+++ b/chipy_org/templates/meetings/past_meetings.html
@@ -22,6 +22,7 @@
       By: {% for presentor in topic.presentors.all %}
             {{presentor.name}}{% if not forloop.last %}, {% endif %}
           {% endfor %}<br />
+      {% if topic.slides_link %}<a href="{{ topic.slides_link }}">Slides Link</a>{% endif %}<br />
       {{ topic.description }}
     </div>
   {% endif %}


### PR DESCRIPTION
I realized the the slides link doesn't seem to appear on past talks.  I've added links to the meetings page to expose this if it's present. 