### PR TITLE
make the talk submission for a bit better and avoid "emailless" submissions

### DIFF
--- a/chipy_org/apps/meetings/forms.py
+++ b/chipy_org/apps/meetings/forms.py
@@ -1,24 +1,30 @@
 from nocaptcha_recaptcha.fields import NoReCaptchaField
-from django.forms import ModelForm, ModelChoiceField
+from django import forms
 from .models import Topic, Presentor, RSVP, Meeting
 import datetime
 
 
-class TopicForm(ModelForm):
+class TopicForm(forms.ModelForm):
     required = (
         'title',
-        'meeting',
+        "name",
+        "email",
         'description',
         'experience_level',
     )
 
-    meeting = ModelChoiceField(queryset=Meeting.objects.filter(when__gt=datetime.datetime.now()))
+    meeting = forms.ModelChoiceField(
+        queryset=Meeting.objects.filter(when__gt=datetime.datetime.now()))
+    name = forms.CharField(label="Your Name", required=True)
+    email = forms.EmailField(label="Your Email", required=True)
 
     def __init__(self, request, *args, **kwargs):
         super(TopicForm, self).__init__(*args, **kwargs)
         self.fields['meeting'].required = False
         self.fields['description'].required = True
         self.fields['experience_level'].required = True
+        self.fields['email'].initial = request.user.email
+        self.fields['name'].initial = request.user.get_full_name()
 
         self.request = request
 
@@ -26,21 +32,29 @@ class TopicForm(ModelForm):
         model = Topic
         fields = (
             'title',
+            "name",
+            "email",
             'meeting',
             'length',
             'experience_level',
             'description',
+            'notes',
             'license',
             'slides_link',
         )
 
     def save(self, commit=True):
         instance = super(TopicForm, self).save(commit=commit)
+        user = self.request.user
+        if not user.email:
+            user.email = self.cleaned_data.get('email')
+            user.save()
+
         if self.request and not instance.presentors.count():
             presenter, created = Presentor.objects.get_or_create(
-                user=self.request.user,
-                name=self.request.user.get_full_name(),
-                email=self.request.user.email,
+                user=user,
+                name=self.cleaned_data.get('name'),
+                email=self.cleaned_data.get('email'),
                 release=True,
             )
 
@@ -48,7 +62,7 @@ class TopicForm(ModelForm):
         return instance
 
 
-class RSVPForm(ModelForm):
+class RSVPForm(forms.ModelForm):
     def __init__(self, request, *args, **kwargs):
         super(RSVPForm, self).__init__(*args, **kwargs)
         self.request = request
@@ -62,7 +76,7 @@ class RSVPForm(ModelForm):
             return self.request.user
 
 
-class AnonymousRSVPForm(ModelForm):
+class AnonymousRSVPForm(forms.ModelForm):
     captcha = NoReCaptchaField()
 
     def __init__(self, request, *args, **kwargs):

--- a/chipy_org/apps/meetings/migrations/0005_auto_20170906_2150.py
+++ b/chipy_org/apps/meetings/migrations/0005_auto_20170906_2150.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meetings', '0004_auto_20170417_2021'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='topic',
+            name='notes',
+            field=models.TextField(help_text='(optional) additional non-public information or context you want us to know about the talk submission.', null=True, verbose_name='Private Submission Notes', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='description',
+            field=models.TextField(help_text='This will be the public talk description.', null=True, verbose_name='Public Description', blank=True),
+        ),
+    ]

--- a/chipy_org/apps/meetings/migrations/0006_auto_20170906_2300.py
+++ b/chipy_org/apps/meetings/migrations/0006_auto_20170906_2300.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meetings', '0005_auto_20170906_2150'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='topic',
+            name='meeting',
+            field=models.ForeignKey(related_name='topics', blank=True, to='meetings.Meeting', help_text="Please select the meeting that you'd like to target your talk for.", null=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='notes',
+            field=models.TextField(help_text='Additional non-public information or context you want us to know about the talk submission.', null=True, verbose_name='Private Submission Notes', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='title',
+            field=models.CharField(help_text='This will be the public title for your talk.', max_length=255),
+        ),
+    ]

--- a/chipy_org/apps/meetings/models.py
+++ b/chipy_org/apps/meetings/models.py
@@ -161,11 +161,15 @@ class Topic(CommonModel):
         return out
 
     title = models.CharField(
+        help_text="This will be the public title for your talk.",
         max_length=MAX_LENGTH)
     presentors = models.ManyToManyField(
         Presentor, blank=True)
     meeting = models.ForeignKey(
-        Meeting, blank=True, null=True, related_name='topics')
+        Meeting, blank=True, null=True, related_name='topics',
+        help_text=(
+            "Please select the meeting that you'd like to "
+            "target your talk for."))
     experience_level = models.CharField(
         "Audience Experience Level",
         max_length=15, blank=True, null=True, choices=EXPERIENCE_LEVELS)
@@ -174,7 +178,15 @@ class Topic(CommonModel):
     length = IntervalField(
         format="M", blank=True, null=True)
     embed_video = models.TextField(blank=True, null=True)
-    description = models.TextField(blank=True, null=True)
+    description = models.TextField(
+        "Public Description", blank=True, null=True,
+        help_text="This will be the public talk description.")
+    notes = models.TextField(
+        "Private Submission Notes",
+        blank=True, null=True,
+        help_text=("Additional non-public information or context "
+                   "you want us to know about the talk submission."),
+    )
     slides_link = models.URLField(blank=True, null=True)
     start_time = models.DateTimeField(blank=True, null=True)
     approved = models.BooleanField(default=False)

--- a/chipy_org/apps/meetings/templates/meetings/propose_topic.html
+++ b/chipy_org/apps/meetings/templates/meetings/propose_topic.html
@@ -8,14 +8,25 @@
 
 {% block body %}
 <div class="row-fluid">
-  <div class="offset4 span8">
+  <div class="span12">
     <h1>Give a talk</h1>
+  </div>
+</div>
+<div class="row-fluid">
+  <div class="span6">
     <p>{% flatblock "speaker_text" %}</p>
+  </div>
+  <div class="span6">
     <form action="{% url 'propose_topic' %}" method="post" id="propose-topic">{% csrf_token %}
       {% for field in form %}
       <div class="fieldWrapper">
+        {% if field.name not in form.required %}
+        <label for="id_{{ field.html_name }}"><strong>{{ field.label }}</strong> (optional)</label>
+        {% else %}
+        <strong><label for="id_{{ field.html_name }}"><strong>{{ field.label }}</strong></label></strong>
+        {% endif %}
         {{ field.errors }}
-        {% if field.name not in form.required %}<label for="id_{{ field.html_name }}">{{ field.label }} (optional)</label>{% else %}{{ field.label_tag }}{% endif %}{{ field }}
+        <div class="help-text">{{ field.help_text }}</div>{{ field }}
       </div>
       {% endfor %}
       <p><input type="submit" value="Submit topic" id="propose_submit" class="btn btn-primary"/></p>

--- a/chipy_org/static/css/chipy.css
+++ b/chipy_org/static/css/chipy.css
@@ -7261,6 +7261,9 @@ hr {
 #edit-profile input[type="submit"] {
   margin-top: 10px;
 }
+form .help-text {
+      color: #888;
+}
 form .errorlist {
   margin: 0px;
   width: 314px;

--- a/chipy_org/static/less/chipy.less
+++ b/chipy_org/static/less/chipy.less
@@ -153,6 +153,9 @@ hr {
 }
 
 form {
+  .help-text {
+      color: #888;
+  }
   .errorlist {
     margin: 0px;
     width: 314px;


### PR DESCRIPTION
This pull request enhances the talk submission form:

- [x] FIX: the glaring issue where emails/names are missing from talk submissions.  Now email and name is a required and it pre-populates the form field from the user record if available.  If the user record has an empty email, this will also update that email address. 
- [x] add an optional Notes field for speakers to enter non-public context about their talk
- [x] update the layout a bit, so it makes better use of space on the page
- [x] added helptext to some of the fields for better explanation