### PR TITLE
Replace members header link with code of conduct

### DIFF
--- a/chipy_org/templates/site_base.html
+++ b/chipy_org/templates/site_base.html
@@ -32,12 +32,12 @@
 {% block nav %}
     <ul class="nav">
         <li><a href="/#about">About</a></li>
+        <li><a href="/pages/conduct">Code of Conduct</a></li>
         <li><a href="{% url 'sponsor_list' %}">Sponsor</a></li>
         <li><a href="/pages/host/">Host</a></li>
         <li><a href="/pages/referrals/">Referrals</a></li>
         <li><a href="/pages/donate/">Donate</a></li>
         <li><a href="{% url 'propose_topic' %}">Speak</a></li>
-        <li><a href="{% url 'profiles:list' %}">Members</a></li>
         <li><a href="http://www.chipymentor.org/">Mentorship</a></li>
         <li><a href="/pages/sigs/">SIGs</a></li>
         <li><a href="{% url 'contact' %}">Contact</a></li>


### PR DESCRIPTION
We discussed this, but the Members page isn't useful for most users and the code of conduct is.

It also feels better to put it right after `About` so it's front and center.

@JoeJasinski 