### PR TITLE
Fix link for Mentorship Site

### DIFF
--- a/chipy_org/templates/site_base.html
+++ b/chipy_org/templates/site_base.html
@@ -38,7 +38,7 @@
         <li><a href="/pages/referrals/">Referrals</a></li>
         <li><a href="/pages/donate/">Donate</a></li>
         <li><a href="{% url 'propose_topic' %}">Speak</a></li>
-        <li><a href="http://www.chipymentor.org/">Mentorship</a></li>
+        <li><a href="https://chipymentor.org/">Mentorship</a></li>
         <li><a href="/pages/sigs/">SIGs</a></li>
         <li><a href="{% url 'contact' %}">Contact</a></li>
     </ul>


### PR DESCRIPTION
The new site has some issues with the subdomain redirects. Let's just point to the actual domain. 