### PR TITLE
#131 - Removing outdated references to Eldarion/Symposium in License File

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,4 @@
-Symposium code is:
-
-Copyright (c) 2000-2012 Eldarion, Inc and contributors.
-
-All else is:
-
-Copyright (c) 2012-2014 Chicago Python User Group and contributors.
+Copyright (c) 2012-2019 Chicago Python User Group and contributors.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
Original Issue: [#131 - Chipy.org LICENSE file references wrong project](https://github.com/chicagopython/chipy.org/issues/131)

**Problem:** License file referenced old software (Pinax/Symposium/Eldarion)
**Solution:** Removed top part of license file that referenced the outdated information and updated ChiPy copyright year end date from 2014 --> 2019.