### PR TITLE
Issue #179 - Paginate Past Meetings

### DIFF
--- a/chipy_org/apps/meetings/templates/meetings/past_meetings.html
+++ b/chipy_org/apps/meetings/templates/meetings/past_meetings.html
@@ -65,4 +65,27 @@
 </div>
 <hr>
 {% endfor %}
+
+
+{% if is_paginated %}
+  <ul class="pagination">
+    {% if page_obj.has_previous %}
+      <li><a href="?page={{ page_obj.previous_page_number }}">&laquo;</a></li>
+    {% else %}
+      <li class="disabled"><span>&laquo;</span></li>
+    {% endif %}
+    {% for i in paginator.page_range %}
+      {% if page_obj.number == i %}
+        <li class="active"><span>{{ i }}</span></li>
+      {% else %}
+        <li><a href="?page={{ i }}">{{ i }}</a></li>
+      {% endif %}
+    {% endfor %}
+    {% if page_obj.has_next %}
+      <li><a href="?page={{ page_obj.next_page_number }}">&raquo;</a></li>
+    {% else %}
+      <li class="disabled"><span>&raquo;</span></li>
+    {% endif %}
+  </ul>
+{% endif %}
 {% endblock body %}

--- a/chipy_org/apps/meetings/views.py
+++ b/chipy_org/apps/meetings/views.py
@@ -44,6 +44,7 @@ class PastMeetings(ListView):
     queryset = Meeting.objects.filter(
         when__lt=datetime.datetime.now() - datetime.timedelta(hours=3)
     ).order_by("-when")
+    paginate_by = 5
 
 
 class MeetingDetail(DetailView):


### PR DESCRIPTION
## Issue #179 

## Problem
As we age we increase our meeting count! Right now we have dozens of
past meetings rendering on our past meetings page. Wouldn't it be great
if we paginated so folks could just look at a few meetings?

## Solution
This uses the pagination approach discussed by the amazing Vitor Freitas
(and others) in his (and other) blog posts:
https://simpleisbetterthancomplex.com/tutorial/2016/08/03/how-to-paginate-with-django.html

Very snazzy and uses all the power of Django! 


## Screenshots

### Page 1
![Screenshot 2019-03-31 17 10 22](https://user-images.githubusercontent.com/5155488/55295950-b10d7000-53d8-11e9-8a32-fb19dfdf2614.png)
### Page 2
![Screenshot 2019-03-31 17 10 26](https://user-images.githubusercontent.com/5155488/55295952-b36fca00-53d8-11e9-9c78-4d325c27656b.png)

### Page 3
![Screenshot 2019-03-31 17 10 30](https://user-images.githubusercontent.com/5155488/55295956-b5398d80-53d8-11e9-9994-6ba009f59d5c.png)


Thanks @vitorfs!