### PR TITLE
Issue #183 - Add Code of Conduct to talk proposals

### DIFF
--- a/chipy_org/apps/meetings/templates/meetings/propose_topic.html
+++ b/chipy_org/apps/meetings/templates/meetings/propose_topic.html
@@ -43,6 +43,23 @@
       <p>Author waives the exclusive right to collect, whether individually or via a performance-rights society, royalties for the public digital performance of the User Submission, subject to the compulsory license created by 17 U.S.C. Section 114 (or the equivalent in other jurisdictions).</p>
       <p>Author specifically affirms the right to perform the User Submissions on the ChiPy's web sites or on other web sites designated by ChiPy (including, but not necessarily limited to YouTube and Google Video).</p>
       <p>Author also hereby grants each person receiving the User Submissions distributed by ChiPy a non-exclusive license to access, use, display, and perform the User Submissions in a non-commercial, private context.</p>
+      <p><em style='font-weight: bold'>Code of Conduct</em>: Author has read <a href='/pages/conduct'>ChiPy's Code of Conduct</a> and will ensure
+      presentation and associated materials (slides, handouts, etc...) do not violate the Code of Conduct. This includes, but is not limited to:
+      <!-- begin Code of Conduct-->
+        <pre>Do:
+  Be kind to others
+  Be professional
+  Use welcoming and inclusive language
+
+Do not:
+  Use hate symbols
+  Using insults, put downs or excessive swearing
+  Publicize of non-harassing private communication
+  Use sexist, racist, hateful or exclusionary jokes
+  Use sexual language and imagery in any event venue
+  Act inappropriately for a diverse, professional audience</pre>
+      </p>
+      <!-- end Code of Conduct-->
       <button class="btn btn-primary" id="agree">I agree</button> <button class="btn" id="cancel">Cancel</button>
     </div>
   </div>

--- a/chipy_org/apps/meetings/templates/meetings/propose_topic.html
+++ b/chipy_org/apps/meetings/templates/meetings/propose_topic.html
@@ -43,23 +43,7 @@
       <p>Author waives the exclusive right to collect, whether individually or via a performance-rights society, royalties for the public digital performance of the User Submission, subject to the compulsory license created by 17 U.S.C. Section 114 (or the equivalent in other jurisdictions).</p>
       <p>Author specifically affirms the right to perform the User Submissions on the ChiPy's web sites or on other web sites designated by ChiPy (including, but not necessarily limited to YouTube and Google Video).</p>
       <p>Author also hereby grants each person receiving the User Submissions distributed by ChiPy a non-exclusive license to access, use, display, and perform the User Submissions in a non-commercial, private context.</p>
-      <p><em style='font-weight: bold'>Code of Conduct</em>: Author has read <a href='/pages/conduct'>ChiPy's Code of Conduct</a> and will ensure
-      presentation and associated materials (slides, handouts, etc...) do not violate the Code of Conduct. This includes, but is not limited to:
-      <!-- begin Code of Conduct-->
-        <pre>Do:
-  Be kind to others
-  Be professional
-  Use welcoming and inclusive language
-
-Do not:
-  Use hate symbols
-  Using insults, put downs or excessive swearing
-  Publicize of non-harassing private communication
-  Use sexist, racist, hateful or exclusionary jokes
-  Use sexual language and imagery in any event venue
-  Act inappropriately for a diverse, professional audience</pre>
-      </p>
-      <!-- end Code of Conduct-->
+      {% flatblock "code_of_conduct" %}
       <button class="btn btn-primary" id="agree">I agree</button> <button class="btn" id="cancel">Cancel</button>
     </div>
   </div>

--- a/chipy_org/apps/meetings/templates/meetings/propose_topic.html
+++ b/chipy_org/apps/meetings/templates/meetings/propose_topic.html
@@ -43,7 +43,7 @@
       <p>Author waives the exclusive right to collect, whether individually or via a performance-rights society, royalties for the public digital performance of the User Submission, subject to the compulsory license created by 17 U.S.C. Section 114 (or the equivalent in other jurisdictions).</p>
       <p>Author specifically affirms the right to perform the User Submissions on the ChiPy's web sites or on other web sites designated by ChiPy (including, but not necessarily limited to YouTube and Google Video).</p>
       <p>Author also hereby grants each person receiving the User Submissions distributed by ChiPy a non-exclusive license to access, use, display, and perform the User Submissions in a non-commercial, private context.</p>
-      {% flatblock "code_of_conduct" %}
+      {% flatblock "speakers_code_of_conduct" %}
       <button class="btn btn-primary" id="agree">I agree</button> <button class="btn" id="cancel">Cancel</button>
     </div>
   </div>


### PR DESCRIPTION
## Issue #183 

## Problem

We need presenters to know about our Code of Conduct and ensure they know they need to abide by it.

## Solution

Add abbreviated callouts to the legal language about speaker agreement and talk releases.


### Screenshot

![Screenshot 2019-03-31 17 58 37](https://user-images.githubusercontent.com/5155488/55296445-3e53c300-53df-11e9-995a-39d4d0f9bd93.png)
