### PR TITLE
Improve ToS Agreement on Topic submission

### DIFF
--- a/chipy_org/apps/meetings/templates/meetings/_tos_dialog.js
+++ b/chipy_org/apps/meetings/templates/meetings/_tos_dialog.js
@@ -1,6 +1,6 @@
 $('#propose_submit').click(function(event){
     event.preventDefault();
-    $('#tos-dialog').dialog({width: '500px'});
+    $('#tos-dialog').dialog({width: '50%', modal: true, height: 600});
     $('#agree').click(function(){
         $('#propose-topic').submit();
     });


### PR DESCRIPTION
## Problem
Right now the ToS is not visible or clickable on smaller devices. The
width is too large, and the lack of a max height prevents the user from
scrolling to see the whole modal.

## Solution
This PR is a hacky improvement to just ensure that one is able to scroll
down if the text isn't visable. It also dictates that modals should be a
percentage of the total, not a fixed width size.

### Before 
![Screenshot 2019-07-01 22 16 46](https://user-images.githubusercontent.com/5155488/60480224-61944580-9c4e-11e9-9424-6d59107f3c70.png)


### After
![Screenshot 2019-07-01 22 17 04](https://user-images.githubusercontent.com/5155488/60480227-6527cc80-9c4e-11e9-86ba-a40f27be5fe6.png)
![Screenshot 2019-07-01 22 17 12](https://user-images.githubusercontent.com/5155488/60480230-6658f980-9c4e-11e9-9319-498440630b04.png)
