### PR TITLE
Add ChiPy Giving as top nav and collapse nav elements

### DIFF
--- a/chipy_org/templates/site_base.html
+++ b/chipy_org/templates/site_base.html
@@ -33,10 +33,18 @@
     <ul class="nav">
         <li><a href="/#about">About</a></li>
         <li><a href="/pages/conduct">Code of Conduct</a></li>
-        <li><a href="{% url 'sponsor_list' %}">Sponsor</a></li>
-        <li><a href="/pages/host/">Host</a></li>
-        <li><a href="/pages/referrals/">Referrals</a></li>
-        <li><a href="/pages/donate/">Donate</a></li>
+        <li class="dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Support Us
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+            <a href="{% url 'sponsor_list' %}">Sponsor</a>
+            <a href="/pages/host/">Host</a>
+            <a href="/pages/referrals/">Referral Program</a>
+            <a href="/pages/donate/">Individual Donation</a>
+          </div>
+        </li>
+        <li><a href="/pages/giving">ChiPy Giving</a></li>
         <li><a href="{% url 'propose_topic' %}">Speak</a></li>
         <li><a href="https://chipymentor.org/">Mentorship</a></li>
         <li><a href="/pages/sigs/">SIGs</a></li>


### PR DESCRIPTION
## Problem

Our nav bar is getting a little crowded. I tried to add the ChiPy giving link (a new top priority) and it's pretty crowded already. 

## Solution

Merge the "Support us" links into one dropdown. This focuses the attentions of sponsors and givers to one place. Maybe they'll find two things they can do! 

ChiPy Giving deserves its own top level element because it's not supporting ChiPy itself, it's supporting everybody!

## Screen shots

Desktop / Large Screen

<img width="799" alt="Screenshot 2019-08-13 21 14 24" src="https://user-images.githubusercontent.com/5155488/62989934-ae536a80-be0f-11e9-9266-1b050d9f0494.png">
<img width="761" alt="Screenshot 2019-08-13 21 14 33" src="https://user-images.githubusercontent.com/5155488/62989942-b3b0b500-be0f-11e9-9764-ad4b7e0491d1.png">

Mobile / Small Screen

<img width="489" alt="Screenshot 2019-08-13 21 14 57" src="https://user-images.githubusercontent.com/5155488/62989957-bc08f000-be0f-11e9-91d5-ef8404a4bbc4.png">
