### PR TITLE
Add SponsorGroup and render sponsors according to level

### DIFF
--- a/chipy_org/apps/sponsors/admin.py
+++ b/chipy_org/apps/sponsors/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Sponsor, MeetingSponsor, GeneralSponsor
+from .models import Sponsor, SponsorGroup, MeetingSponsor, GeneralSponsor
 
 
 class MeetingSponsorInline(admin.StackedInline):
@@ -18,5 +18,11 @@ class SponsorAdmin(admin.ModelAdmin):
     prepopulated_fields = {"slug": ("name",)}
 
 
+class SponsorGroupAdmin(admin.ModelAdmin):
+    list_display = ["name"]
+    search_fields = ["name"]
+
+
 admin.site.register(Sponsor, SponsorAdmin)
+admin.site.register(SponsorGroup, SponsorGroupAdmin)
 admin.site.register(GeneralSponsor, GeneralSponsorAdmin)

--- a/chipy_org/apps/sponsors/migrations/0002_auto_20191021_2221.py
+++ b/chipy_org/apps/sponsors/migrations/0002_auto_20191021_2221.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sponsors', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SponsorGroup',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=80)),
+                ('list_priority', models.IntegerField(default=5)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='sponsor',
+            name='sponsor_group',
+            field=models.ForeignKey(related_name='sponsors', blank=True, to='sponsors.SponsorGroup', null=True),
+        ),
+    ]

--- a/chipy_org/apps/sponsors/models.py
+++ b/chipy_org/apps/sponsors/models.py
@@ -39,6 +39,14 @@ class GeneralSponsor(models.Model):
         ordering = ["sponsor__name"]
 
 
+class SponsorGroup(models.Model):
+    name = models.CharField(max_length=80)
+    list_priority = models.IntegerField(default=5)
+
+    def __str__(self):
+        return self.name
+
+
 class Sponsor(models.Model):
 
     name = models.CharField(max_length=80)
@@ -49,6 +57,7 @@ class Sponsor(models.Model):
         upload_to="sponsor_logos", blank=True, null=True,
         help_text=("All logos will be cropped to fit a 4 by 3 aspect ratio. "
                    "Resolution should be at minimum 400x300."))
+    sponsor_group = models.ForeignKey(SponsorGroup, related_name='sponsors', blank=True, null=True)
 
     def __str__(self):
         return "{name}".format(name=self.name)

--- a/chipy_org/apps/sponsors/templates/sponsors/sponsor_list.html
+++ b/chipy_org/apps/sponsors/templates/sponsors/sponsor_list.html
@@ -8,23 +8,28 @@
 <h2>ChiPy Sponsors</h2>
 <p>{% flatblock "sponsor_info_text" %}</p>
 
-{% for sponsor in sponsors %}
-<div class="row">
+{% for group in sponsor_groups %}
+  <div class="container">
+    <h3>{{ group.name }}</h3>
+  {% for sponsor in group.sponsors.all %}
+  <div class="row">
 
-    {% if sponsor.logo %}
-    {% thumbnail sponsor.logo "100" crop="center" as im %}
-    <div class="span2 sponsor-image">
-        <a href="{% url 'sponsor_detail' sponsor.slug %}"><img src="{{ im.url }}" alt="{{ sponsor.name }}"></a>
-    </div>
-    {% endthumbnail %}
-    {% else %}
-    <div class="span2 sponsor-image">&nbsp;</div>
-    {% endif %}
-    <h4 class="span3">{{ sponsor.name }}</h4>
-    <div class="span6"><a href="{% url 'sponsor_detail' sponsor.slug %}">More Info</a></div>
+      {% if sponsor.logo %}
+      {% thumbnail sponsor.logo "100" crop="center" as im %}
+      <div class="span2 sponsor-image">
+          <a href="{% url 'sponsor_detail' sponsor.slug %}"><img src="{{ im.url }}" alt="{{ sponsor.name }}"></a>
+      </div>
+      {% endthumbnail %}
+      {% else %}
+      <div class="span2 sponsor-image">&nbsp;</div>
+      {% endif %}
+      <h4 class="span3">{{ sponsor.name }}</h4>
+      <div class="span6"><a href="{% url 'sponsor_detail' sponsor.slug %}">More Info</a></div>
 
-</div>
-<hr>
+  </div>
+  <hr>
+  {% endfor %}
+  </div>
 {% endfor %}
 
 {% endblock body %}

--- a/chipy_org/apps/sponsors/views.py
+++ b/chipy_org/apps/sponsors/views.py
@@ -1,5 +1,5 @@
 from django.views.generic import DetailView, ListView
-from .models import Sponsor
+from .models import Sponsor, SponsorGroup
 
 
 class SponsorDetailView(DetailView):
@@ -9,9 +9,15 @@ class SponsorDetailView(DetailView):
 
 
 class SponsorListView(ListView):
-    model = Sponsor
-    context_object_name = "sponsors"
+    model = SponsorGroup
+    context_object_name = "sponsor_groups"
     template_name = "sponsors/sponsor_list.html"
 
     def get_queryset(self):
-        return super(SponsorListView, self).get_queryset().order_by('name')
+        return (
+            super(SponsorListView, self)
+                .get_queryset()
+                .filter(sponsors__isnull=False)
+                .prefetch_related('sponsors')
+                .order_by('list_priority', 'name')
+        )


### PR DESCRIPTION
## Problem
We are trying to expose our sponsorship levels to be a bit more visible
on the site. Right now the sponsors are all listed in alphabetical order
with no precedence for sponsor levels. We want to call out significant
sponsors first (for example if Zoro was our top sponsor), rather than
listing them last because of the alphabetical.

## Solution

This introduces a new model called SponsorGroup to let us be flexible
about naming. We can introduce new groups or change orders with the
list_priority as need be, and the groups will only be displayed if
there's a corresponding Sponsor in the Group.

Example of Before:

![Screenshot 2019-10-21 22 04 58](https://user-images.githubusercontent.com/5155488/67257988-22d00880-f454-11e9-9915-e3b87982dfcb.png)


Example of After:

![Screenshot 2019-10-21 22 37 35](https://user-images.githubusercontent.com/5155488/67257992-26fc2600-f454-11e9-9aef-5e52b55c7cd4.png)

@JoeJasinski @ZaxR @eevelweezel 