### PR TITLE
Added make shell Command for Local Development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ up:
 shell:
 	@echo "Opening shell in docker container"
 	@echo "Use this shell to run python and django commands normally"
-	@docker-compose exec web sh
+	@docker-compose exec web bash
 
 web: run
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ run:
 up:
 	docker-compose up -d
 
+shell:
+	@echo "Opening shell in docker container"
+	@echo "Use this shell to run python and django commands normally"
+	@docker-compose exec web sh
+
 web: run
 
 migrate:


### PR DESCRIPTION
I found runing manage.py and pytest commands via docker-compose verbose.  This pull request adds a `shell` command to the Makefile.  The command opens a shell in the web container allowing local use of manage.py, pytest, pylint, etc. directly.    

