### PR TITLE
Stylize homepage

### DIFF
--- a/chipy_org/templates/envelope/contact.html
+++ b/chipy_org/templates/envelope/contact.html
@@ -5,12 +5,22 @@
 
 {% block body %}
   <h1>{% trans 'Contact us' %}</h1>
-  <div id="contact">
-    <form method="post" id="contact-us" action=".">
-      {% csrf_token %}
-      {% antispam_fields %}
-      {{ form.as_p }}
-      <input class="btn btn-primary" type="submit" value="Send Email">
-    </form>
-  </div>
+  <div class="row-fluid">
+      <div class="module span6">
+        <div id="contact">
+          <form method="post" id="contact-us" action=".">
+            {% csrf_token %}
+            {% antispam_fields %}
+            {{ form.as_p }}
+            <input class="btn btn-primary" type="submit" value="Send Email">
+          </form>
+        </div>
+      </div>
+      <div class="module span6">
+          <h2>Did you know ChiPy has a mailing list?</h3>
+          <p>It's a great place to post a tough question, make an announcement,
+          or leaf through the archives going back to 2005. Get connected with a wealth of resources today!</p>
+          <p><a class="btn" href="http://mail.python.org/mailman/listinfo/chicago">Sign up &raquo;</a></p>
+      </div><!--/span-->
+  </div><!-- #row-fluid -->
 {% endblock %}

--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -314,13 +314,8 @@ h2 a {
 
     <section>
         <div class="row-fluid">
-            <div class="module span6">
-                <h3>Mailing List</h3>
-                <p>Sign up to join the discussion.</p>
-                <p><a class="btn" href="http://mail.python.org/mailman/listinfo/chicago">Sign up &raquo;</a></p>
-            </div>
-            <div class="module span6">
-                <h3>Twitter</h3>
+            <div class="module span12">
+                <h2>Twitter</h2>
                  <p>Follow Us On Twitter! Get the latest tweets in your feed.</p>
                  <p><a class="btn" href="https://twitter.com/ChicagoPython">@ChicagoPython &raquo;</a></p>
                  <a class="twitter-timeline" data-chrome="noheader" data-height=600 href="https://twitter.com/ChicagoPython">Tweets by ChicagoPython</a>

--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -305,10 +305,10 @@ h2 a {
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">
-            <div class="module span3"><a id="icon-github" class="icon box-button" href="https://github.com/chicagopython/chipy.org"></a></div>
-            <div class="module span3"><a id="icon-slack" class="icon box-button" href="https://joinchipyslack.herokuapp.com/"></a></div>
-            <div class="module span3"><a id="icon-meetup" class="icon box-button" href="https://www.meetup.com/_ChiPy_/"></a></div>
-            <div class="module span3"><a id="icon-twitter" class="icon box-button" href="https://twitter.com/chicagopython"></a></div>
+          <div class="module span3"><a id="icon-github" class="icon box-button" href="https://github.com/chicagopython/chipy.org"></a><h4 style='text-align: center'>Collaborate on Code!</h4></div>
+          <div class="module span3"><a id="icon-slack" class="icon box-button" href="https://joinchipyslack.herokuapp.com/"></a><h4 style='text-align: center'>Chat on Slack!</h4></div>
+          <div class="module span3"><a id="icon-meetup" class="icon box-button" href="https://www.meetup.com/_ChiPy_/"></a><h4 style='text-align: center'>Events on Meetup!</h4></div>
+          <div class="module span3"><a id="icon-twitter" class="icon box-button" href="https://twitter.com/chicagopython"></a><h4 style='text-align: center'>Check out our Tweets!</h4></div>
         </div>
     </section>
 

--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -315,14 +315,6 @@ h2 a {
     <section>
         <div class="row-fluid">
             <div class="module span6">
-
-                <h3>Slack</h3>
-                 <p>We're on slack! Join a room, ask questions, make friends!</p>
-                 <p><a class="btn" href="https://joinchipyslack.herokuapp.com/">Join the Conversation &raquo;</a></p>
-
-                <h3>IRC</h3>
-                <p>Some of us like to hang out in the IRC #chipy channel on irc.freenode.net</p>
-                <p><a class="btn" href="irc://irc.freenode.net/chipy">Start chatting &raquo;</a></p>
                 <h3>Mailing List</h3>
                 <p>Sign up to join the discussion.</p>
                 <p><a class="btn" href="http://mail.python.org/mailman/listinfo/chicago">Sign up &raquo;</a></p>


### PR DESCRIPTION
## Problem

Our page is a bit redundant, a bit sparse and not engaging or "fun". Beyond that, our mix of olde-school text and buttons with super-minimal buttons is a little jarring.

## Solution 

Push info into the Icons as commands. Move the Email ListServ Signup to the contact page (we might move it back if we get a cool icon for it). 

### Before

![Screenshot 2019-12-02 19 25 26](https://user-images.githubusercontent.com/5155488/70015794-13100d80-1544-11ea-9013-bff9961459ae.png)
![Screenshot 2019-12-02 20 29 04](https://user-images.githubusercontent.com/5155488/70015835-38048080-1544-11ea-960e-c71aa1d40008.png)

### AFTER

![Screenshot 2019-12-02 20 26 09](https://user-images.githubusercontent.com/5155488/70015801-186d5800-1544-11ea-94b2-9b297d23cdfc.png)
![Screenshot 2019-12-02 20 29 27](https://user-images.githubusercontent.com/5155488/70015836-3a66da80-1544-11ea-9694-56c60e8b139b.png)


### Note
I removed the IRC link (and brought it up at the Board meeting). With the success of Slack, advertising IRC doesn't make sense. We also don't have any Board members using it regularly to be aware of issues with the CoC.