### PR TITLE
WIP - replace interval field with duration field

### DIFF
--- a/chipy_org/apps/meetings/migrations/0009_auto_20191208_1006.py
+++ b/chipy_org/apps/meetings/migrations/0009_auto_20191208_1006.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import tinymce.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meetings', '0008_auto_20190711_1501'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='meeting',
+            name='description',
+            field=tinymce.models.HTMLField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='description',
+            field=tinymce.models.HTMLField(verbose_name='Public Description', blank=True, null=True, help_text='This will be the public talk description.'),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='length',
+            field=models.DurationField(blank=True, null=True),
+        ),
+    ]

--- a/chipy_org/apps/meetings/models.py
+++ b/chipy_org/apps/meetings/models.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from django.db import models
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
-from interval.fields import IntervalField
 from tinymce import models as tinymce_models
 
 from chipy_org.libs.models import CommonModel
@@ -183,8 +182,7 @@ class Topic(CommonModel):
         max_length=15, blank=True, null=True, choices=EXPERIENCE_LEVELS)
     license = models.CharField(
         max_length=50, choices=LICENSE_CHOISES, default='CC BY')
-    length = IntervalField(
-        format="M", blank=True, null=True)
+    length = models.DurationField(blank=True, null=True)
     embed_video = models.TextField(blank=True, null=True)
     description = tinymce_models.HTMLField(
         "Public Description", blank=True, null=True,

--- a/chipy_org/apps/meetings/templates/meetings/meeting.html
+++ b/chipy_org/apps/meetings/templates/meetings/meeting.html
@@ -61,7 +61,7 @@
                 <li>
                   <strong>{{ topic.title }}</strong><br />
                   {% if topic.length %}
-                    ({{ topic.length }} Minutes)<br />
+                    Duration: {{ topic.length}}<br />
                   {% endif %}
                   By: {% for presenter in topic.presentors.all %}
                         {{presenter.name}} {% if not forloop.last %}, {% endif %}

--- a/chipy_org/apps/profiles/migrations/0002_auto_20191208_1007.py
+++ b/chipy_org/apps/profiles/migrations/0002_auto_20191208_1007.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='userprofile',
+            name='display_name',
+            field=models.CharField(verbose_name='Name for Security Check In', max_length=200),
+        ),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='show',
+            field=models.BooleanField(verbose_name='Show my information in the member list', default=False),
+        ),
+    ]

--- a/chipy_org/apps/subgroups/migrations/0002_auto_20191208_1008.py
+++ b/chipy_org/apps/subgroups/migrations/0002_auto_20191208_1008.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subgroups', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='subgroup',
+            name='image',
+            field=models.ImageField(blank=True, null=True, upload_to='group_images'),
+        ),
+    ]

--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -231,7 +231,6 @@ INSTALLED_APPS = [
     'django_gravatar',
     'gunicorn',
     'honeypot',
-    'interval',
     'rest_framework',
     'social_django',
     'storages',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ django-gravatar2==1.1.4
 django-honeypot==0.5.0
 django-ical==1.4
 django-nocaptcha-recaptcha==0.0.19
-django-pgsql-interval-field==0.9.4
 django-storages==1.1.8
 django-tinymce==2.0.6
 Django>=1.7.0,<1.9.0


### PR DESCRIPTION
Closes #222 

This is a still a work in progress as I would like some feedback on design.  Mainly do we want to 

1. preserve the old duration for the talks/topics
2. have a better widget for entering the duration

I personally don't care about the old topic times all that much.  Does anyone on the boar use the historical information.  For example do  we want to know: average python talk time is 15-20 minutes, etc.?  If we want to keep the old data, I can write a custom migration.  

The default widget for this field is a text box with time specified with a format of DD HH:MM:SS.uuuuuu.  This is not the most intuitive entry as a user would need to typically type "15:00" for a 15 minute talk. Type 15 would be better.  I can either put a label with the format "MM:SS" or try to add some custom widget to make this more clear.   

My suggestions would  are:
1. forget about the old data 
2. add the time format of HH:MM:SS to the talk form; admin can correct when approving if needed
3. open a new issue to upgrade the widget if users don't follow the format

Also, I'm not sure why I ended up with migrations in the subgroups and profiles applications.  