### PR TITLE
remove byte string from RSVP CSV

### DIFF
--- a/chipy_org/apps/meetings/utils.py
+++ b/chipy_org/apps/meetings/utils.py
@@ -104,8 +104,3 @@ def meetup_meeting_sync(api_key, meetup_event_id):
             logger.info('Saved RSVP for %s with response of %s',
                         result['member']['name'], rsvp.response)
 
-
-def unicode_convert(inin):
-    if isinstance(inin, str):
-        return inin.encode("utf-8")
-    return inin

--- a/chipy_org/apps/meetings/views.py
+++ b/chipy_org/apps/meetings/views.py
@@ -23,7 +23,7 @@ from rest_framework.views import APIView
 import probablepeople
 
 from chipy_org.apps.meetings.forms import RSVPForm, AnonymousRSVPForm
-from .utils import meetup_meeting_sync, unicode_convert
+from .utils import meetup_meeting_sync 
 from .email import send_rsvp_email, send_meeting_topic_submitted_email
 
 from .forms import TopicForm, RSVPForm, AnonymousRSVPForm
@@ -240,7 +240,6 @@ class RSVPlistCSVBase(RSVPlist):
                     first_name,
                     last_name,
                     item.guests]
-            row = [unicode_convert(x) for x in row]
             yield row
 
     def render_to_response(self, context, **response_kwargs):


### PR DESCRIPTION
Removes unicode_convert and the associated uses from the code base. 