### PR TITLE
Remove Interval Field from Topics Model

### DIFF
--- a/chipy_org/apps/meetings/admin.py
+++ b/chipy_org/apps/meetings/admin.py
@@ -20,6 +20,7 @@ class TopicInline(admin.StackedInline):
     filter_horizontal = ['presentors']
     readonly_fields = ['modified', 'created', ]
     extra = 0
+    exclude = ['length',]
 
 
 class TopicAdmin(admin.ModelAdmin):
@@ -28,6 +29,7 @@ class TopicAdmin(admin.ModelAdmin):
     list_filter = ['approved', 'experience_level']
     search_fields = ['title']
     filter_horizontal = ['presentors']
+    exclude = ['length',]
 
     def get_presenters(self, obj):
         return format_html(" &bull; ".join(

--- a/chipy_org/apps/meetings/forms.py
+++ b/chipy_org/apps/meetings/forms.py
@@ -35,7 +35,7 @@ class TopicForm(forms.ModelForm):
             "name",
             "email",
             'meeting',
-            'length',
+            'length_minutes',
             'experience_level',
             'description',
             'notes',

--- a/chipy_org/apps/meetings/migrations/0009_auto_20191231_1735.py
+++ b/chipy_org/apps/meetings/migrations/0009_auto_20191231_1735.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import tinymce.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meetings', '0008_auto_20190711_1501'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='topic',
+            name='length_minutes',
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='meeting',
+            name='description',
+            field=tinymce.models.HTMLField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='description',
+            field=tinymce.models.HTMLField(verbose_name='Public Description', blank=True, null=True, help_text='This will be the public talk description.'),
+        ),
+    ]

--- a/chipy_org/apps/meetings/migrations/0010_auto_20191231_1757.py
+++ b/chipy_org/apps/meetings/migrations/0010_auto_20191231_1757.py
@@ -4,6 +4,17 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 
+def populate_length_minutes(apps, schema_editor):
+    Topic = apps.get_model('meetings', 'Topic')
+    for topic in Topic.objects.all():
+        try:
+            minutes = int(topic.length.total_seconds()/60)
+            topic.length_minutes = minutes
+            topic.save()
+        except:
+            pass
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -11,4 +22,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(populate_length_minutes),
     ]

--- a/chipy_org/apps/meetings/migrations/0010_auto_20191231_1757.py
+++ b/chipy_org/apps/meetings/migrations/0010_auto_20191231_1757.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meetings', '0009_auto_20191231_1735'),
+    ]
+
+    operations = [
+    ]

--- a/chipy_org/apps/meetings/models.py
+++ b/chipy_org/apps/meetings/models.py
@@ -185,6 +185,7 @@ class Topic(CommonModel):
         max_length=50, choices=LICENSE_CHOISES, default='CC BY')
     length = IntervalField(
         format="M", blank=True, null=True)
+    length_minutes = models.IntegerField(blank=True, null=True)
     embed_video = models.TextField(blank=True, null=True)
     description = tinymce_models.HTMLField(
         "Public Description", blank=True, null=True,

--- a/chipy_org/apps/meetings/templates/meetings/meeting.html
+++ b/chipy_org/apps/meetings/templates/meetings/meeting.html
@@ -62,16 +62,16 @@
               {% for topic in meeting.topics.active %}
                 <li>
                   <strong>{{ topic.title }}</strong><br />
-                  {% if topic.length %}
-                    ({{ topic.length }} Minutes)<br />
-                  {% endif %}
                   By: {% for presenter in topic.presentors.all %}
                         {{presenter.name}} {% if not forloop.last %}, {% endif %}
                       {% endfor %}<br />
                   {% if topic.experience_level %}
                   Experience Level: {{ topic.get_experience_level_display }}<br />
                   {% endif %}
-                  {{ topic.description|bleach|safe }}
+                  {% if topic.length_minutes %}
+                    Length: {{ topic.length_minutes }} Minutes<br />
+                  {% endif %}
+                  Description: {{ topic.description|bleach|safe }}
                 </li>
               {% endfor %}
             </ul>

--- a/chipy_org/apps/profiles/migrations/0002_auto_20191231_1735.py
+++ b/chipy_org/apps/profiles/migrations/0002_auto_20191231_1735.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='userprofile',
+            name='display_name',
+            field=models.CharField(verbose_name='Name for Security Check In', max_length=200),
+        ),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='show',
+            field=models.BooleanField(verbose_name='Show my information in the member list', default=False),
+        ),
+    ]

--- a/chipy_org/apps/subgroups/migrations/0002_auto_20191231_1735.py
+++ b/chipy_org/apps/subgroups/migrations/0002_auto_20191231_1735.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subgroups', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='subgroup',
+            name='image',
+            field=models.ImageField(blank=True, null=True, upload_to='group_images'),
+        ),
+    ]

--- a/meeting.html
+++ b/meeting.html
@@ -60,8 +60,8 @@
               {% for topic in meeting.topics.active %}
                 <li>
                   <strong>{{ topic.title }}</strong><br />
-                  {% if topic.length %}
-                    ({{ topic.length }} Minutes)<br />
+                  {% if topic.length_minutes %}
+                    ({{ topic.length_minutes }} Minutes)<br />
                   {% endif %}
                   By: {% for presenter in topic.presentors.all %}
                         {{presenter.name}} {% if not forloop.last %}, {% endif %}


### PR DESCRIPTION
This is the first step in removing the interval field.

This pull request does the following:
1. Adds an integer field length_minutes to Topics model
2. Adds a data migration to populate the new length_minutes field with data from the old length field
3. Updates the admin, forms and templates to only use the new length_minutes field

There are probably two more deploys needed: 
1. Delete the length field from the model 
2. Remove the django-interval-field from the project
