### PR TITLE
add cache_dir as /home/app/.pytest_cache

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 DJANGO_SETTINGS_MODULE = chipy_org.settings_test
 python_files = tests.py test_*.py *_tests.py
 addopts = --nomigrations -v
+cache_dir = /home/app/.pytest_cache


### PR DESCRIPTION
closes #240 

I went with the third option: specify the cache directory in /home/app