### PR TITLE
BUG FIX: Topic Emails

### DIFF
--- a/chipy_org/apps/meetings/templates/meetings/emails/meeting_topic_submitted.html
+++ b/chipy_org/apps/meetings/templates/meetings/emails/meeting_topic_submitted.html
@@ -1,3 +1,5 @@
+{% load bleach_tags %}
+
 <p>A meeting topic has been submitted:<p>
 
 <p><a href="https://{{ site.domain }}{% url 'admin:meetings_topic_change' topic.id %}">https://{{ site.domain }}{% url 'admin:meetings_topic_change' topic.id %}</a></p>

--- a/chipy_org/apps/meetings/tests.py
+++ b/chipy_org/apps/meetings/tests.py
@@ -142,3 +142,26 @@ def test_post_topic_sends_email():
 
     email.send_meeting_topic_submitted_email(t)
     assert len(mail.outbox) == 1
+
+
+def test_anonymous_rsvp_email():
+    m = Meeting(
+        when=datetime.datetime.now(),
+        reg_close_date=datetime.datetime.now(),
+        description="Test",
+    )
+    m.save()
+    assert len(Meeting.objects.all()) == 1
+
+    rsvp = RSVP(
+        last_name='last name',
+        first_name='first_name',
+        email='test@test.com', 
+        meeting=m,
+        response='Y',
+    )
+    rsvp.save()
+    assert len(RSVP.objects.all()) == 1
+
+    email.send_rsvp_email(rsvp)
+    assert len(mail.outbox) == 1

--- a/chipy_org/apps/meetings/tests.py
+++ b/chipy_org/apps/meetings/tests.py
@@ -4,12 +4,15 @@ import pytest
 import django
 from django.test import TestCase, override_settings
 from django.test import Client
+from django.core import mail
 from django.core.urlresolvers import reverse
 from django.conf import global_settings
 from django.contrib.auth import get_user_model
 
 import chipy_org.libs.test_utils as test_utils
 from .models import RSVP, Meeting, Venue, Topic
+from . import email
+
 
 User = get_user_model()
 
@@ -116,3 +119,26 @@ class SmokeTest(TestCase):
 
         # CHECK
         self.assertEqual(response.status_code, 200)
+
+
+def test_post_topic_sends_email():
+    m = Meeting(
+        when=datetime.datetime.now(),
+        reg_close_date=datetime.datetime.now(), 
+        description="Test"
+    )
+    m.save()
+    assert len(Meeting.objects.all()) == 1
+
+    t = Topic(
+        title="Test Meeting",
+        meeting=m,
+        experience_level='novice',
+        length_minutes=10,
+        description="Test Topic",
+    )
+    t.save()
+    assert len(Topic.objects.all()) == 1
+
+    email.send_meeting_topic_submitted_email(t)
+    assert len(mail.outbox) == 1


### PR DESCRIPTION
I added a bleach tag to the topic HTML email template.  Without this the send_meeting_topic_submitted_email function to crashes when rendering the template.   

See issue #248 