### PR TITLE
Added custom meeting titles

### DIFF
--- a/chipy_org/apps/meetings/admin.py
+++ b/chipy_org/apps/meetings/admin.py
@@ -57,7 +57,7 @@ class MeetingForm(forms.ModelForm):
 
 
 class MeetingAdmin(admin.ModelAdmin):
-    list_display = ['when', 'where', 'created', 'modified', 'action', 'meeting_type']
+    list_display = [ 'title', 'meeting_type', 'when', 'where', 'created', 'modified', 'action' ]
     list_filter = ['meeting_type']
     form = MeetingForm
     inlines = [

--- a/chipy_org/apps/meetings/migrations/0015_auto_20200208_1904.py
+++ b/chipy_org/apps/meetings/migrations/0015_auto_20200208_1904.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meetings', '0014_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='meeting',
+            name='custom_title',
+            field=models.CharField(max_length=64, blank=True, null=True, help_text="If you fill out this field, this 'custom_title' will show up as the title of the event."),
+        ),
+        migrations.AddField(
+            model_name='meetingtype',
+            name='default_title',
+            field=models.CharField(max_length=64, blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='meeting',
+            name='meeting_type',
+            field=models.ForeignKey(blank=True, null=True, help_text='Type of meeting (i.e. SIG Meeting, Mentorship Meeting, Startup Row, etc.). Leave this empty for the main meeting. ', to='meetings.MeetingType'),
+        ),
+    ]

--- a/chipy_org/apps/meetings/models.py
+++ b/chipy_org/apps/meetings/models.py
@@ -63,6 +63,7 @@ class MeetingType(CommonModel):
         'subgroups.SubGroup', blank=True, null=True,
         help_text='Optional Sub-group (i.e. SIG)')
     name = models.CharField(max_length=64)
+    default_title = models.CharField(max_length=64, null=True, blank=True)
     slug = models.SlugField(max_length=64, unique=True)
     description = tinymce_models.HTMLField(blank=True, null=True)
 
@@ -95,7 +96,11 @@ class Meeting(CommonModel):
         MeetingType, blank=True, null=True,
         help_text=("Type of meeting (i.e. SIG Meeting, "
                    "Mentorship Meeting, Startup Row, etc.). "
-                   "Leave this empty for the main meeting."))
+                   "Leave this empty for the main meeting. "
+                   ))
+    custom_title = models.CharField(max_length=64, null=True, blank=True,
+        help_text=("If you fill out this field, this 'custom_title' will show up as the title of the event." 
+                   ))
     description = tinymce_models.HTMLField(blank=True, null=True)
 
     def can_register(self):
@@ -124,7 +129,14 @@ class Meeting(CommonModel):
     def meetup_url(self):
         return "https://www.meetup.com/_ChiPy_/events/{}/".format(self.meetup_id)
 
-
+    @property 
+    def title(self):
+        if self.custom_title:
+            return self.custom_title
+        if self.meeting_type and self.meeting_type.default_title:
+            return self.meeting_type.default_title
+        return "In the Loop" # quasi default title for the main meeting
+    
 class Presentor(CommonModel):
 
     def __str__(self):

--- a/chipy_org/apps/meetings/templates/meetings/meeting.html
+++ b/chipy_org/apps/meetings/templates/meetings/meeting.html
@@ -13,11 +13,12 @@
 
     <div class="row-fluid">
       <div class="span12">
-          {% if meeting.meeting_type %}
-          <h3 itemprop="name">{{ meeting.meeting_type.name }}</h3>
-          {% if meeting.meeting_type.subgroup %}<p><a href="{% url 'groups' meeting.meeting_type.subgroup.slug %}">{{ meeting.meeting_type.subgroup.name }}</a></p>{% endif %}
+          {% if meeting.title %}
+              <h3 itemprop="name">{{ meeting.title }}</h3>
           {% endif %}
+
           <hr />
+
           {% if meeting.description %}
           <p itemprop="description">{{ meeting.description|bleach|safe }}</p>
           {% endif %}

--- a/chipy_org/apps/meetings/tests.py
+++ b/chipy_org/apps/meetings/tests.py
@@ -10,9 +10,8 @@ from django.conf import global_settings
 from django.contrib.auth import get_user_model
 
 import chipy_org.libs.test_utils as test_utils
-from .models import RSVP, Meeting, Venue, Topic
+from .models import RSVP, Meeting, Venue, Topic, MeetingType
 from . import email
-
 
 User = get_user_model()
 
@@ -165,3 +164,31 @@ def test_anonymous_rsvp_email():
 
     email.send_rsvp_email(rsvp)
     assert len(mail.outbox) == 1
+
+
+class MeetingTitleTest(TestCase):
+    # Tests if 'custom_title' from 'meeting' is available, it'll be used as 'title' for meeting.
+    # If 'custom_title' from 'meeting' isn't available, the 'default_title' from 'meeting_type' will be used as 'title' for meeting.
+
+    def setUp(self):
+        self.meeting_type_non_main = MeetingType.objects.create(name='Non Main Sig ', default_title='Non Main Default Title')
+
+    def test_non_main_meeting_without_custom_field(self): 
+        meeting = Meeting.objects.create(
+            when = datetime.date.today(), meeting_type = self.meeting_type_non_main)
+        self.assertEqual(meeting.title, 'Non Main Default Title')
+
+    def test_main_meeting_without_custom_field(self):
+        meeting = Meeting.objects.create(
+            when = datetime.date.today())
+        self.assertEqual(meeting.title, 'In the Loop')
+
+    def test_non_main_meeting_with_custom_field(self):
+        meeting = Meeting.objects.create(
+            when = datetime.date.today(), meeting_type = self.meeting_type_non_main, custom_title = 'Non Main Custom Title')
+        self.assertEqual(meeting.title, 'Non Main Custom Title')
+
+    def test_main_meeting_with_custom_field(self):
+        meeting = Meeting.objects.create(
+            when = datetime.date.today(), custom_title = 'Main Custom Title')
+        self.assertEqual(meeting.title, 'Main Custom Title')

--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -132,7 +132,10 @@ h2 a {
 
         <div class="row-fluid">
             <div class="module span6">
-                <h3>In the Loop</h3>
+                {% if next_meeting.title %}
+                    <h3>{{ next_meeting.title }}</h3>
+                {% endif %}
+
                 <p>Meetings happen in the downtown area the second Thursday of every month.</p>
 
                 {% if next_meeting %}
@@ -250,14 +253,13 @@ h2 a {
         <div class="row-fluid">
             {% for meeting in other_meetings %}
             <div class="module span4 box-feature" itemscope itemtype="http://schema.org/Event">
-
-                {% if meeting.meeting_type %}
-                <h4 itemprop="name">{{ meeting.meeting_type.name }}</h4>
-
-                {% if meeting.meeting_type.subgroup %}<p><a href="{% url 'groups' meeting.meeting_type.subgroup.slug %}">{{ meeting.meeting_type.subgroup.name }}</a></p>{% endif %}
-
+                
+                {% if meeting.title %}
+                    <h4 itemprop="name">{{ meeting.title }}</h4>
                 {% endif %}
+
                 <hr />
+
                 {% if meeting.description %}
                 <p itemprop="description">{{ meeting.description|truncatewords_html:30|safe }}</p>
                 {% endif %}


### PR DESCRIPTION
Fixes #218 

-Adds 'default_title' field to 'meeting_type'
-Adds 'custom_title' field to 'meeting'

If the 'custom title' field, that will be used as the event title. If 'custom title' field is blank, 'default_title' field will be used as the event title. 

-Also added tests to test the title functionality 