### PR TITLE
Converted subheadings on homepage from links to divs

### DIFF
--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -127,7 +127,7 @@ h2 a {
     <section itemscope itemtype="http://schema.org/Event">
 
         <div class="row-fluid">
-            <div itemprop="name" class="module span12"><h2><a name="next-meeting">Next Main Meeting</a></h2></div>
+            <div itemprop="name" class="module span12"><h2><div name="next-meeting">Next Main Meeting</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">
@@ -244,7 +244,7 @@ h2 a {
 
     <section id="section-other-events">
         <div class="row-fluid">
-            <div class="module span12"><h2><a name="upcoming-events">Upcoming Events</a></h2></div>
+            <div class="module span12"><h2><div name="upcoming-events">Upcoming Events</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">
@@ -297,14 +297,14 @@ h2 a {
 
     <section>
         <div class="row-fluid">
-            <div class="module span12"><h2><a name="about">About</a></h2></div>
+            <div class="module span12"><h2><div name="about">About</div></h2></div>
         </div><!-- #row-fluid -->
         <p>{% flatblock "homepage_welcome_text" %}</p>
     </section>
 
     <section>
         <div class="row-fluid">
-            <div class="module span12"><h2><a name="participate">Participate</a></h2></div>
+            <div class="module span12"><h2><div name="participate">Participate</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">
@@ -330,7 +330,7 @@ h2 a {
 
     <section>
         <div class="row-fluid">
-            <div class="module span12"><h2><a name="sponsors">Sponsors</a></h2></div>
+            <div class="module span12"><h2><div name="sponsors">Sponsors</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">


### PR DESCRIPTION
Fixes #251 

Changed 'a' tags to div tags on the subheadings: 
"Next Main Meeting", "Upcoming Events", "About", "Participate", "Sponsors"