### PR TITLE
Add resetdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ shell:
 psql:
 	@docker-compose exec db psql chipy chipy
 
+resetdb:
+	@docker-compose exec db psql chipy chipy -c "drop schema if exists public cascade;"
+	@docker-compose exec db psql chipy chipy -c "create schema public;"
+
 web: run
 
 migrate:

--- a/chipy_org/apps/meetings/admin.py
+++ b/chipy_org/apps/meetings/admin.py
@@ -57,7 +57,7 @@ class MeetingForm(forms.ModelForm):
 
 
 class MeetingAdmin(admin.ModelAdmin):
-    list_display = [ 'title', 'meeting_type', 'when', 'where', 'created', 'modified', 'action' ]
+    list_display = ['title', 'meeting_type', 'when', 'where', 'created', 'modified', 'action']
     list_filter = ['meeting_type']
     form = MeetingForm
     inlines = [

--- a/chipy_org/apps/meetings/models.py
+++ b/chipy_org/apps/meetings/models.py
@@ -97,10 +97,12 @@ class Meeting(CommonModel):
         help_text=("Type of meeting (i.e. SIG Meeting, "
                    "Mentorship Meeting, Startup Row, etc.). "
                    "Leave this empty for the main meeting. "
-                   ))
-    custom_title = models.CharField(max_length=64, null=True, blank=True,
-        help_text=("If you fill out this field, this 'custom_title' will show up as the title of the event." 
-                   ))
+                  ))
+    custom_title = models.CharField(
+        max_length=64, null=True, blank=True,
+        help_text=("If you fill out this field, this 'custom_title'"
+                   "will show up as the title of the event."
+                  ))
     description = tinymce_models.HTMLField(blank=True, null=True)
 
     def can_register(self):
@@ -129,14 +131,14 @@ class Meeting(CommonModel):
     def meetup_url(self):
         return "https://www.meetup.com/_ChiPy_/events/{}/".format(self.meetup_id)
 
-    @property 
+    @property
     def title(self):
         if self.custom_title:
             return self.custom_title
         if self.meeting_type and self.meeting_type.default_title:
             return self.meeting_type.default_title
         return "In the Loop" # quasi default title for the main meeting
-    
+
 class Presentor(CommonModel):
 
     def __str__(self):

--- a/chipy_org/apps/meetings/tests.py
+++ b/chipy_org/apps/meetings/tests.py
@@ -167,28 +167,36 @@ def test_anonymous_rsvp_email():
 
 
 class MeetingTitleTest(TestCase):
-    # Tests if 'custom_title' from 'meeting' is available, it'll be used as 'title' for meeting.
-    # If 'custom_title' from 'meeting' isn't available, the 'default_title' from 'meeting_type' will be used as 'title' for meeting.
+    # Tests if 'custom_title' from 'meeting' is available, it'll be used as
+    # 'title' for meeting.  If 'custom_title' from 'meeting' isn't available,
+    # the 'default_title' from 'meeting_type' will be used as 'title' for
+    # meeting.
 
     def setUp(self):
-        self.meeting_type_non_main = MeetingType.objects.create(name='Non Main Sig ', default_title='Non Main Default Title')
+        self.meeting_type_non_main = MeetingType.objects.create(
+            name='Non Main Sig ',
+            default_title='Non Main Default Title')
 
-    def test_non_main_meeting_without_custom_field(self): 
+    def test_non_main_meeting_without_custom_field(self):
         meeting = Meeting.objects.create(
-            when = datetime.date.today(), meeting_type = self.meeting_type_non_main)
+            when=datetime.date.today(),
+            meeting_type=self.meeting_type_non_main)
         self.assertEqual(meeting.title, 'Non Main Default Title')
 
     def test_main_meeting_without_custom_field(self):
         meeting = Meeting.objects.create(
-            when = datetime.date.today())
+            when=datetime.date.today())
         self.assertEqual(meeting.title, 'In the Loop')
 
     def test_non_main_meeting_with_custom_field(self):
         meeting = Meeting.objects.create(
-            when = datetime.date.today(), meeting_type = self.meeting_type_non_main, custom_title = 'Non Main Custom Title')
+            when=datetime.date.today(),
+            meeting_type=self.meeting_type_non_main,
+            custom_title='Non Main Custom Title')
         self.assertEqual(meeting.title, 'Non Main Custom Title')
 
     def test_main_meeting_with_custom_field(self):
         meeting = Meeting.objects.create(
-            when = datetime.date.today(), custom_title = 'Main Custom Title')
+            when=datetime.date.today(),
+            custom_title='Main Custom Title')
         self.assertEqual(meeting.title, 'Main Custom Title')


### PR DESCRIPTION
## Problem

Resetting a database when migrations are involved is a pain. It should be really easy to get back to a fresh db image.

## Solution

Add `make resetdb`. This will drop the main schema (`public`) and all of its tables. Once ready, it will recreate the main schema.