### PR TITLE
Upgrade to Python 3.7.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.9
+FROM python:3.7.6
 
 # install os dependencies; clean apt cache
 RUN apt-get update && apt-get install -y \

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.9
+python-3.7.6


### PR DESCRIPTION
## Problem

We want to keep moving toward the latest and greatest Python has to offer! 3.6 is wonderful, but we should get to 3.8 by the end of the year.

## Solution

This was a pretty painless migration to 3.7.6. I had this running quietly in the background while working on https://github.com/chicagopython/chipy.org/pull/262. No issues detected, but any bugs should be easy enough to repair as we go. This migration has been pretty painless on other projects.

@chicagopython/web-guild 