### PR TITLE
Upgrade django storages

### DIFF
--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -96,7 +96,7 @@ if USE_S3:
     AWS_HEADERS = {
         'Cache-Control': 'max-age=86400',
     }
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     #STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
     # these next two aren't used, but staticfiles will complain without them
     #STATIC_URL = "https://%s.s3.amazonaws.com/static/" % os.environ['AWS_STORAGE_BUCKET_NAME']

--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -96,7 +96,7 @@ if USE_S3:
     AWS_HEADERS = {
         'Cache-Control': 'max-age=86400',
     }
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3BotoStorage'
     #STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
     # these next two aren't used, but staticfiles will complain without them
     #STATIC_URL = "https://%s.s3.amazonaws.com/static/" % os.environ['AWS_STORAGE_BUCKET_NAME']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# boto==2.49.0
 boto3==1.12.16
 dj-database-url==0.4.2
 django-admin-tools==0.8.1
@@ -14,7 +13,6 @@ django-gravatar2==1.1.4
 django-honeypot==0.5.0
 django-ical==1.4
 django-nocaptcha-recaptcha==0.0.20
-# django-storages==1.1.8
 django-storages==1.9.1
 django-tinymce==2.8.0
 Django==1.11.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.12.16
 dj-database-url==0.4.2
 django-admin-tools==0.8.1
 django-bleach==0.6.1
-django-ckeditor==5.2.2
+django-ckeditor==5.9.0
 django-envelope==1.3
 django-extensions==2.2.8
 django-flatblocks==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-boto==2.49.0
+# boto==2.49.0
+boto3==1.12.16
 dj-database-url==0.4.2
 django-admin-tools==0.8.1
 django-bleach==0.6.1
@@ -13,7 +14,8 @@ django-gravatar2==1.1.4
 django-honeypot==0.5.0
 django-ical==1.4
 django-nocaptcha-recaptcha==0.0.20
-django-storages==1.1.8
+# django-storages==1.1.8
+django-storages==1.9.1
 django-tinymce==2.8.0
 Django==1.11.28
 djangorestframework==3.10.3


### PR DESCRIPTION
This will put the sponsor logos back on the site.  Old version of django-storages is  not compatible with python3.  