### PR TITLE
Homepage sponsor link and alphabetical ordering of sponsors

### DIFF
--- a/chipy_org/apps/sponsors/models.py
+++ b/chipy_org/apps/sponsors/models.py
@@ -61,3 +61,6 @@ class Sponsor(models.Model):
 
     def get_absolute_url(self):
         return reverse("sponsor_detail", args=[self.slug])
+
+    class Meta:
+        ordering = ["name"]

--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -332,28 +332,7 @@ h2 a {
 
     <section>
         <div class="row-fluid">
-            <div class="module span12"><h2><div name="sponsors">Sponsors</div></h2></div>
-        </div><!-- #row-fluid -->
-
-        <div class="row-fluid">
-            <div class="module span12">
-
-                {% if general_sponsors %}
-                <h3>Platinum Sponsors</h3>
-                {% for general_sponsor in general_sponsors %}
-                  <div class="sponsor-home-block">
-                     {% thumbnail general_sponsor.sponsor.logo "400" crop="center" as im %}
-                     <div class="sponsor-home-image">
-                         <a href="{% url 'sponsor_detail' general_sponsor.sponsor.slug %}">
-                             <img src="{{ im.url }}" alt="{{ general_sponsor.sponsor.name }} (Sponsor)">
-                         </a>
-                     </div>
-                     {% endthumbnail %}
-                  </div>
-                {% endfor %}
-                {% endif %}
-
-            </div><!--/span-->
+            <div class="module span12"><h2><a href="{% url 'sponsor_list' %}" name="sponsors">Visit Our Sponsors</a></h2></div>
         </div><!-- #row-fluid -->
     </section>
 


### PR DESCRIPTION
-Removed the sponsor logos on bottom of homepage and replaced it with a link to the sponsor list page

-Changed the ordering of sponsors so that they are listed in ascending alphabetical order