### PR TITLE
added the presenters to the topic admin list page

### DIFF
--- a/chipy_org/apps/meetings/admin.py
+++ b/chipy_org/apps/meetings/admin.py
@@ -23,7 +23,7 @@ class TopicInline(admin.StackedInline):
 
 
 class TopicAdmin(admin.ModelAdmin):
-    list_display = ('id', 'approved', 'title', 'experience_level', 'meeting', 'created')
+    list_display = ('id', 'approved', 'title', 'experience_level', 'get_presenters', 'meeting', 'created')
     readonly_fields = ['get_presenters', 'modified', 'created', ]
     list_filter = ['approved', 'experience_level']
     search_fields = ['title']
@@ -31,7 +31,7 @@ class TopicAdmin(admin.ModelAdmin):
 
     def get_presenters(self, obj):
         return format_html(" &bull; ".join(
-            [f"<a href='{reverse('admin:meetings_presentor_change', args=[p.id])}'>{p}</a>"
+            [f"<a href='{reverse('admin:meetings_presentor_change', args=[p.id])}'>{p.name}</a>"
              for p
              in obj.presentors.all()]))
     get_presenters.short_description = "Presenter Links"
@@ -79,7 +79,7 @@ class MeetingAdmin(admin.ModelAdmin):
 
 class PresentorAdmin(admin.ModelAdmin):
     list_display = [
-        'id', 'user', 'email', 'phone']
+        'id', 'name', 'user', 'email', 'phone']
     search_fields = [
         'user__username', 'user__first_name', 'user__last_name',
         'email', 'phone']

--- a/chipy_org/apps/meetings/models.py
+++ b/chipy_org/apps/meetings/models.py
@@ -178,8 +178,6 @@ class Topic(CommonModel):
 
     def __str__(self):
         out = self.title
-        if self.presentors.count():
-            out += f" By: {self.presentors.all()[0].name}"
         return out
 
     title = models.CharField(


### PR DESCRIPTION
As a speaker coordinator, I want to view what speakers are associated with what topics as I browse the topics list. 

This PR is to make it easier to see who is associated with topics that are submitted without drilling down into the topic detail page. 

![Screen Shot 2020-04-13 at 9 37 29 PM](https://user-images.githubusercontent.com/417872/79180760-620e5f00-7dd0-11ea-8651-19d8b6060199.png)

This PR also:
 - Adds a name field to the Speaker List page
 - Fixes a recursive call bug with the display of Topics when the adding a topic for the first time and no presenters are attached.
