### PR TITLE
Redirect fix for login, fix for access to job_post object in admin, and other changes

### DIFF
--- a/chipy_org/apps/job_board/admin.py
+++ b/chipy_org/apps/job_board/admin.py
@@ -20,7 +20,7 @@ class JobPostAdmin(admin.ModelAdmin):
 
     # Substitute the CharField Widget for a TextArea Widget.
     # This is used for the 'description' CharField in the admin
-    def formfield_for_dbfield(self, db_field, **kwargs):
+    def formfield_for_dbfield(self, db_field, **kwargs):  # pylint: disable=arguments-differ
         formfield = super(JobPostAdmin, self).formfield_for_dbfield(db_field, **kwargs)
         if db_field.name == "description":
             formfield.widget = forms.Textarea(attrs=formfield.widget.attrs)

--- a/chipy_org/apps/job_board/admin.py
+++ b/chipy_org/apps/job_board/admin.py
@@ -20,7 +20,7 @@ class JobPostAdmin(admin.ModelAdmin):
 
     # Substitute the CharField Widget for a TextArea Widget.
     # This is used for the 'description' CharField in the admin
-    def formfield_for_dbfield(self, db_field, _, **kwargs):
+    def formfield_for_dbfield(self, db_field, **kwargs):
         formfield = super(JobPostAdmin, self).formfield_for_dbfield(db_field, **kwargs)
         if db_field.name == "description":
             formfield.widget = forms.Textarea(attrs=formfield.widget.attrs)

--- a/chipy_org/apps/job_board/forms.py
+++ b/chipy_org/apps/job_board/forms.py
@@ -20,7 +20,6 @@ class JobPostForm(forms.ModelForm):
             "is_sponsor",
             "can_host_meeting",
             "company_website",
-            # "contact",
             "agree_to_terms",
         ]
 

--- a/chipy_org/apps/job_board/forms.py
+++ b/chipy_org/apps/job_board/forms.py
@@ -31,6 +31,12 @@ class JobPostForm(forms.ModelForm):
 
 
 class JobUserForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(JobUserForm, self).__init__(*args, **kwargs)
+        self.fields["first_name"].required = True
+        self.fields["last_name"].required = True
+        self.fields["email"].required = True
+        
     class Meta:
         model = User
 

--- a/chipy_org/apps/job_board/forms.py
+++ b/chipy_org/apps/job_board/forms.py
@@ -20,7 +20,7 @@ class JobPostForm(forms.ModelForm):
             "is_sponsor",
             "can_host_meeting",
             "company_website",
-            "contact",
+            # "contact",
             "agree_to_terms",
         ]
 
@@ -36,7 +36,7 @@ class JobUserForm(forms.ModelForm):
         self.fields["first_name"].required = True
         self.fields["last_name"].required = True
         self.fields["email"].required = True
-        
+
     class Meta:
         model = User
 

--- a/chipy_org/apps/job_board/templates/after_submit_job_post.html
+++ b/chipy_org/apps/job_board/templates/after_submit_job_post.html
@@ -6,6 +6,6 @@
 <br>
 It will have to be approved by an admin in order to show up on the job board. 
 <br>
-The status is: pending approval. 
+The status is: Submitted. 
 </h4>
 {% endblock body %}

--- a/chipy_org/apps/job_board/templates/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_post_form.html
@@ -15,8 +15,6 @@
       {% if field == job_post_form.agree_to_terms %}
         {{field}} I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>, which includes giving a referral fee when a candidate is hired/placed.
         <p>
-      {% elif field == job_post_form.contact %}
-         {{field}}
       {% else %}  
         {{field.label_tag}} {{field.errors}}
         {{field}} 

--- a/chipy_org/apps/job_board/views.py
+++ b/chipy_org/apps/job_board/views.py
@@ -11,12 +11,14 @@ from django.views.generic import ListView, DetailView
 from chipy_org.apps.job_board.forms import JobPostForm, JobUserForm, JobProfileForm
 from .models import JobPost
 
+
 @login_required
 def create_job_post(request):
 
     if request.method == "POST":
 
-        job_post_form = JobPostForm(request.POST)
+        job_post = JobPost(contact=request.user)
+        job_post_form = JobPostForm(request.POST, instance=job_post)
         job_user_form = JobUserForm(request.POST, instance=request.user)
         job_profile_form = JobProfileForm(request.POST, instance=request.user.profile)
 
@@ -29,9 +31,8 @@ def create_job_post(request):
             return HttpResponseRedirect(reverse("after-submit-job-post"))
 
     else:
-        job_post_form = JobPostForm(
-            initial={"contact": request.user}
-        )  # sets an intial value only for unbound form, not for bound form
+        job_post = JobPost(contact=request.user)
+        job_post_form = JobPostForm(instance=job_post)
         job_user_form = JobUserForm(instance=request.user)
         job_profile_form = JobProfileForm(instance=request.user.profile)
 

--- a/chipy_org/templates/_login_options.html
+++ b/chipy_org/templates/_login_options.html
@@ -1,5 +1,5 @@
 
 Sign in with <br>
-<a href="{% url 'social:begin' 'google-oauth2' %}?{{ redirect_querystring }}"><button class="zocial google">Google</button></a><br>
-<a href="{% url 'social:begin' 'github' %}?{{ redirect_querystring }}"><button class="zocial github">Github</button></a><br>
+<a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.GET.next }}"><button class="zocial google">Google</button></a><br>
+<a href="{% url 'social:begin' 'github' %}?next={{ request.GET.next }}"><button class="zocial github">Github</button></a><br>
 <button class="zocial openid" id="openid-button">OpenID</button><br>


### PR DESCRIPTION
- Redirect fix for login. When logging into the job posting page, the user will be correctly redirected back to that page after logging in with Social Auth. For the general chipy.org site, the user will be redirected to the 'next' parameter after login (i.e. the page they started from before they had to login)

- Because of an extra parameter (an underscore) in a function in 'admin.py', this prevented an admin from accessing the job post object. This pull request removes that underscore paramater.
 
- Refactored the view function for the job post form to not depend on a hidden form field called 'contact'. Doing it this way make it less error prone. 

- Other small changes