### PR TITLE
fixes about link on homepage

### DIFF
--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -303,7 +303,7 @@ h2 a {
 
     <section>
         <div class="row-fluid">
-            <div class="module span12"><h2><div name="about">About</div></h2></div>
+            <div class="module span12"><h2><div id="about">About</div></h2></div>
         </div><!-- #row-fluid -->
         <p>{% flatblock "homepage_welcome_text" %}</p>
     </section>

--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -131,7 +131,7 @@ h2 a {
     <section itemscope itemtype="http://schema.org/Event">
 
         <div class="row-fluid">
-            <div itemprop="name" class="module span12"><h2><div name="next-meeting">Next Main Meeting</div></h2></div>
+            <div itemprop="name" class="module span12"><h2><div id="next-meeting">Next Main Meeting</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">
@@ -251,7 +251,7 @@ h2 a {
 
     <section id="section-other-events">
         <div class="row-fluid">
-            <div class="module span12"><h2><div name="upcoming-events">Upcoming Events</div></h2></div>
+            <div class="module span12"><h2><div id="upcoming-events">Upcoming Events</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">
@@ -310,7 +310,7 @@ h2 a {
 
     <section>
         <div class="row-fluid">
-            <div class="module span10"><h2><div name="participate">Participate</div></h2></div>
+            <div class="module span10"><h2><div id="participate">Participate</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">
@@ -337,7 +337,7 @@ h2 a {
 
     <section>
         <div class="row-fluid">
-            <div class="module span12"><h2><div name="sponsors">Sponsors</div></h2></div>
+            <div class="module span12"><h2><div id="sponsors">Sponsors</div></h2></div>
         </div><!-- #row-fluid -->
 
         <div class="row-fluid">


### PR DESCRIPTION
Changes `name=about` to `id=about` so the about link on the homepage works.  