### PR TITLE
Don't 500 on blank form submissions to RSVP

### DIFF
--- a/chipy_org/apps/meetings/forms.py
+++ b/chipy_org/apps/meetings/forms.py
@@ -68,6 +68,9 @@ class TopicForm(forms.ModelForm):
 class RSVPForm(forms.ModelForm):
     def __init__(self, request, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        for field in ["email", "first_name", "last_name"]:
+            self.fields[field].required = True
+
         if self.instance.pk:
             del self.fields["email"]
 

--- a/chipy_org/apps/meetings/tests.py
+++ b/chipy_org/apps/meetings/tests.py
@@ -180,3 +180,25 @@ class MeetingTitleTest(TestCase):
             when=datetime.date.today(), custom_title="Main Custom Title"
         )
         self.assertEqual(meeting.title, "Main Custom Title")
+
+@override_settings(STATICFILES_STORAGE=global_settings.STATICFILES_STORAGE)
+def test_rsvp_works_for_anonymous_user(client):
+    meeting = Meeting.objects.create(
+        when=datetime.date.today() + datetime.timedelta(days=1)
+    )
+    route = reverse("rsvp")
+    response = client.post(route, data={
+        "meeting": meeting.id,
+        "first_name": "Some",
+        "last_name": "Body",
+        "email": "somebody@example.com",
+    })
+    assert response.status_code == 200
+
+@override_settings(STATICFILES_STORAGE=global_settings.STATICFILES_STORAGE)
+def test_rsvp_fails_gracefully_with_missing_data(client):
+    meeting = Meeting.objects.create(
+        when=datetime.date.today() + datetime.timedelta(days=1)
+    )
+    response = client.post(reverse("rsvp"), data={"meeting": meeting.id})
+    assert response.status_code == 200

--- a/chipy_org/settings_test.py
+++ b/chipy_org/settings_test.py
@@ -3,7 +3,7 @@ from .settings import *
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:", "TEST": {}}}
 DEBUG = True
-ADMINS = "admin@chipy.org"
+ADMINS = ["admin@chipy.org"]
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 ENVELOPE_EMAIL_RECIPIENTS = "admin@example.com"
 


### PR DESCRIPTION
## Problem
Fixes #282 

We're getting 500 errors on form submissions.

## Solution

1. Verify we can test a working form
2. Write a test of a malformed form
3. Verify that 500 is occurring
4. Add required fields

New behavior: 

![Screen Shot 2020-04-30 at 7 17 14 PM](https://user-images.githubusercontent.com/5155488/80771112-fd653b00-8b17-11ea-9ac1-a17a12f607a0.png)


Additionally, if someone bypasses the JS subscriptions it will redirect to a (very ugly) page showing form submission errors. 