### PR TITLE
adds -j 0 to pylint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test:
 	docker-compose exec web pytest -v chipy_org/
 
 lint:
-	docker-compose exec web pylint chipy_org/
+	docker-compose exec web pylint -j 0 chipy_org/
 
 format:
 	docker-compose exec web black .


### PR DESCRIPTION
The -j 0 automatically detects the number of cores and runs pylint in parallel.  On my system using the -j 0 option reduced lint time from around 30 seconds to 22 seconds.  
