### PR TITLE
Updated README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ format-check:
 
 setup: setup_env build
 
-super: 
+superuser: 
 	docker-compose exec web ./manage.py createsuperuser
 
-log: 
+tail-logs: 
 	docker-compose logs -f web

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ format-check:
 
 setup: setup_env build
 
-super: docker-compose exec web ./manage.py createsuperuser
+super: 
+	docker-compose exec web ./manage.py createsuperuser
 
-log: docker-compose logs -f web
+log: 
+	docker-compose logs -f web

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ format:
 	docker-compose exec web black .
 
 format-check:
+	docker-compose exec web isort -rc -tc --atomic --diff .
 	docker-compose exec web black --diff .
 
 setup: setup_env build
+
+super: docker-compose exec web ./manage.py createsuperuser
+
+log: docker-compose logs -f web

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can confirm that the migrations were successful. To do this, run `make shell
 
 Next, you should create a superuser to use to login to the site admin with.
 
-    make super
+    make superuser
 
 Finally, you should be able to visit your site by entering the
 following in your url bar:
@@ -122,7 +122,7 @@ once your app is running with `make up`:
 If you want to see the application logs, use the following command. To stop
 viewing the logs, you can press ctl-c.
 
-    make log
+    make tail-logs
 
 To run an arbitrary Django management command, you can use the following form.
 The below example shows you how to run the `help` management command, but

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ For Windows users, we recommend using the package manager Chocolatey to install 
 
 ## Setting up a Local Development Environment using Docker
 
-Clone the repo
+Sign into your GitHub account. Make a fork of the ChiPy repo at https://github.com/chicagopython/chipy.org by going there and clicking "Fork" on the upper right corner.
 
-    git clone git://github.com/chicagopython/chipy.org.git chipy.org
+Clone this forked repo to your local computer (replace your GitHub username without the brackets): 
+
+    git clone https://github.com/<your-GitHub-username>/chipy.org.git chipy.org
 
 Make the project directory your working directory:
 
@@ -72,15 +74,11 @@ create the tables and database objects needed to run the site.
 
     make migrate
 
-Note: After executing `make migrate`, there will be an error message. If the message reads `psycopg2.ProgrammingError: relation "django_site" does not exist`, you can ignore this error message.
-
-Confirm that the migrations were successful. To do this, run `make shell` , which gives you a Bash shell within Docker. Then run `python manage.py migrate --list` . This shows a list of all the migrations. Make sure each migration has a marked checkbox, such as `[X] 0001_initial` . Then exit out of the shell by typing `exit` .
-
-If after running `make migrate` for the first time, you get a different error message than the message above, you should troubleshoot it.
+You can confirm that the migrations were successful. To do this, run `make shell` , which gives you a Bash shell within Docker. Then run `python manage.py migrate --list` . This shows a list of all the migrations. Make sure each migration has a marked checkbox, such as `[X] 0001_initial` . Then exit out of the shell by typing `exit` .
 
 Next, you should create a superuser to use to login to the site admin with.
 
-    docker-compose exec web ./manage.py createsuperuser
+    make super
 
 Finally, you should be able to visit your site by entering the
 following in your url bar:
@@ -106,15 +104,26 @@ If you would like to run the Pylint linting process, run the following:
 
     make lint
 
+Chipy.org uses Black to have consistently formatted code. We also use isort to 
+arrange import statements correctly. Code must be formatted before merging code.
+If you would like to format code, run the following:
+
+    make format
+
+Note: the command `make format` overwrites your files. To see a preview of what formatted code would 
+look without overwriting your files, run the following:
+
+    make format-check
+
 If you want to execute a shell into your container, run the following:
 once your app is running with `make up`:
 
-    docker-compose exec web bash
+    make shell
 
 If you want to see the application logs, use the following command. To stop
 viewing the logs, you can press ctl-c.
 
-    docker-compose logs -f web
+    make log
 
 To run an arbitrary Django management command, you can use the following form.
 The below example shows you how to run the `help` management command, but

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ If you would like to format code, run the following:
 
     make format
 
-Note: the command `make format` overwrites your files. To see a preview of what formatted code would 
-look without overwriting your files, run the following:
+Note: the command `make format` overwrites your files. Also, that command will format your entire local repo, not only the files that you may have created or edited. As a result, if it formats old, unformatted code, that will show up as a diff in your pull request. To see a preview of what formatted code would look without overwriting your files, run the following:
 
     make format-check
 


### PR DESCRIPTION
In the Makefile, I added make instructions to create a superuser and view logs. Also added seeing a preview of what the isort function would look like under the 'format-check'.

In the README, I did the following changes:
- Told the user to fork the repo, and then clone it.
- Removed the info about having errors after running the 'make migrate' command, because we no longer have errors (Thanks to @elmq0022 for ironing out those errors)
- Added info regarding 'make format' and 'make format-check'
- Added info regarding 'make shell' and 'make log' 