### PR TITLE
removes httplib2 and oauth2 requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,6 @@ Django==2.2.12
 djangorestframework==3.11.0 # how to test
 feedparser==5.2.1
 gunicorn==20.0.4
-httplib2==0.17.0
-oauth2==1.9.0post1 # what's using this?
 probablepeople==0.5.4 # kill
 Pillow==6.2.2
 psycopg2-binary==2.8.4


### PR DESCRIPTION
These two packages seem to be dead weight.  I removed them and was able to login with both google and github accounts.  git grep oaut2 / git grep httplib2 don't produce any meaningful results for these packages.  