### PR TITLE
Implement min height in job board (#302)

### DIFF
--- a/chipy_org/apps/job_board/templates/after_submit_job_post.html
+++ b/chipy_org/apps/job_board/templates/after_submit_job_post.html
@@ -1,4 +1,4 @@
-{% extends "site_base.html" %}
+{% extends "job_board/base.html" %}
 
 {% block body %}
 

--- a/chipy_org/apps/job_board/templates/job_board/base.html
+++ b/chipy_org/apps/job_board/templates/job_board/base.html
@@ -1,0 +1,20 @@
+{% extends "site_base.html" %}
+
+{% block extra_head %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-2413988-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+
+<style>
+    #maincontent {
+        min-height: 20em;
+    }
+</style>
+{% endblock %}

--- a/chipy_org/apps/job_board/templates/job_post_detail.html
+++ b/chipy_org/apps/job_board/templates/job_post_detail.html
@@ -1,4 +1,4 @@
-{% extends "site_base.html" %}
+{% extends "job_board/base.html" %}
 
 {% block body %}
 

--- a/chipy_org/apps/job_board/templates/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_post_form.html
@@ -1,4 +1,4 @@
-{% extends "site_base.html" %}
+{% extends "job_board/base.html" %}
     
 
 {% block body %}

--- a/chipy_org/apps/job_board/templates/job_post_list.html
+++ b/chipy_org/apps/job_board/templates/job_post_list.html
@@ -1,4 +1,4 @@
-{% extends "site_base.html" %}
+{% extends "job_board/base.html" %}
 
 
 {% block body %}

--- a/chipy_org/templates/theme_bootstrap/base.html
+++ b/chipy_org/templates/theme_bootstrap/base.html
@@ -61,7 +61,7 @@
         {% endblock %}
 
         {% block body_base %}
-            <div class="container">
+            <div class="container" id="maincontent">             
                 {% include "_messages.html" %}
                 {% block body %}
                 {% endblock %}


### PR DESCRIPTION
## Problem
@alysivji pointed out that the footer was crowding the top. 

https://github.com/chicagopython/chipy.org/issues/270#issuecomment-624396508

## Solution
This PR gives a minimum height for all the template pages in the Job Board, which pushes the footer down. In the very far future, there'll be a site redesign for chipy, which will give us a more long term solution.
![footer](https://user-images.githubusercontent.com/53249319/88750221-a5d86a80-d11a-11ea-83b6-2639442fc78d.JPG)
