### PR TITLE
Job board bug - Only set job post approval and expiration on initial approval

### DIFF
--- a/chipy_org/apps/job_board/models.py
+++ b/chipy_org/apps/job_board/models.py
@@ -105,7 +105,8 @@ class JobPost(CommonModel):
             self.status_change_date = datetime.datetime.now()
             self.__original_status = self.status
 
-        if self.status == "AP":  # if post is approved, set the approval date and expiration date
+        # if post is approved, set the approval date and expiration date
+        if self.status == "AP" and not self.approval_date:
             self.approval_date = datetime.datetime.now()
             self.expiration_date = self.approval_date + datetime.timedelta(days=self.days_to_expire)
 


### PR DESCRIPTION
While browsing the code, I noticed that a JobPost will have its approval data and expiration date updated whenever it's saved. I assume this isn't intended functionality since it isn't explicit.