### PR TITLE
Change path parameters to query string parameters

### DIFF
--- a/chipy_org/apps/job_board/templates/job_board/delete_job_post.html
+++ b/chipy_org/apps/job_board/templates/job_board/delete_job_post.html
@@ -11,6 +11,6 @@
     
     </form>
 
-        <a href="{% url 'after-submit-job-post' action='show' %}" class="btn btn-primary">Cancel</a>
+        <a href="{% url 'after-submit-job-post' %}" class="btn btn-primary">Cancel</a>
 
 {% endblock body %}

--- a/chipy_org/apps/job_board/templates/job_board/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_board/job_post_form.html
@@ -79,7 +79,7 @@
       <input type="submit" value="Create Post" class="btn btn-primary" >
     {% elif view_action == "update" %}
       <input type="submit" value="Update Post" class="btn btn-primary" >
-      <a href="{% url 'after-submit-job-post' action='show' %}" class="btn btn-info">Cancel</a>
+      <a href="{% url 'after-submit-job-post' %}" class="btn btn-info">Cancel</a>
     {% endif %}
 
 </form>

--- a/chipy_org/apps/job_board/urls.py
+++ b/chipy_org/apps/job_board/urls.py
@@ -15,5 +15,5 @@ urlpatterns = [
     path(r"delete/<int:pk>/", delete_job_post, name="delete-job-post"),
     path("", JobPostList.as_view(), name="job-board"),
     path(r"detail/<int:pk>/", JobPostDetail.as_view(), name="job-post-detail"),
-    path(r"after-submit/<str:action>/", AfterSubmitJobPost.as_view(), name="after-submit-job-post"),
+    path(r"after-submit/", AfterSubmitJobPost.as_view(), name="after-submit-job-post"),
 ]

--- a/chipy_org/apps/job_board/views.py
+++ b/chipy_org/apps/job_board/views.py
@@ -213,7 +213,10 @@ def url_with_query_string(path, **kwargs):
     # to create url with query string parameters.
     # For example,
     # url_with_query_string(reverse('example'), action='create', num=1, msg="well done!")
-    # yields https://www.chipy.org/job-board/example/?action=create&num=1&msg=well+done%21
+    # yields https://www.chipy.org/job-board/example/?action=create&num=1&msg=well+done%21 .
+
+    # Code is from user 'geekQ' from
+    # https://stackoverflow.com/questions/2778247/how-do-i-construct-a-django-reverse-url-using-query-args
 
     encoded_url = path + "?" + urllib.parse.urlencode(kwargs)
     return encoded_url

--- a/chipy_org/templates/site_base.html
+++ b/chipy_org/templates/site_base.html
@@ -53,7 +53,7 @@
         <li><a href="{% url 'job-board' %}">Job Board</a></li>
         
         {% if user.is_authenticated %}
-        <li><a href="{% url 'after-submit-job-post' action='show' %}">My Jobs</a></li>
+        <li><a href="{% url 'after-submit-job-post' %}">My Jobs</a></li>
         {% endif %}
     </ul>
 {% endblock %}


### PR DESCRIPTION
This PR refactors code so that instead of using path parameters (such as in `after-submit/<int:action>/` where 'action' is the path parameter), the "after-submit-job-post" page uses query string parameters `(such as http://chipy.org/job-board/after-submit/?action=create)` to control code logic.
