### PR TITLE
displays truncated html for topic descriptions on homepage

### DIFF
--- a/chipy_org/templates/homepage.html
+++ b/chipy_org/templates/homepage.html
@@ -239,7 +239,7 @@ h2 a {
                       {% if topic.experience_level %}
                       Experience Level: {{ topic.get_experience_level_display }}<br />
                       {% endif %}
-                      {{ topic.description|striptags|truncatewords:80|bleach|safe }}<br />
+                      {{ topic.description|bleach|truncatewords_html:80|safe }}<br />
                       <a href="{% url 'meeting' next_meeting.pk %}">Learn more</a>
                     </li>
                   {% endfor %}


### PR DESCRIPTION
So with the related pull request #334 we have nice rich text available to our presenters when they create a talk.  This pull request ensures the text will look the same on the homepage after it's approved.    