### PR TITLE
Update showmigrations command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ create the tables and database objects needed to run the site.
 
     make migrate
 
-You can confirm that the migrations were successful. To do this, run `make shell` , which gives you a Bash shell within Docker. Then run `python manage.py migrate --list` . This shows a list of all the migrations. Make sure each migration has a marked checkbox, such as `[X] 0001_initial` . Then exit out of the shell by typing `exit` .
+You can confirm that the migrations were successful. To do this, run `make shell` , which gives you a Bash shell within Docker. Then run `python manage.py showmigrations` . This shows a list of all the migrations. Make sure each migration has a marked checkbox, such as `[X] 0001_initial` . Then exit out of the shell by typing `exit` .
 
 Next, you should create a superuser to use to login to the site admin with.
 


### PR DESCRIPTION
This PR corrects a command in the README from `python manage.py migrate --list` to Django's [showmigrations](https://docs.djangoproject.com/en/3.1/ref/django-admin/#django-admin-showmigrations) command: `python manage.py showmigrations`

The previous command did not work for me inside the chipy.org Docker container (right after running `make up` and `make migrations`):

```
root@f0970eff4823:/site/proj# python manage.py migrate --list
usage: manage.py migrate [-h] [--noinput] [--database DATABASE] [--fake]
                         [--fake-initial] [--plan] [--run-syncdb] [--version]
                         [-v {0,1,2,3}] [--settings SETTINGS]
                         [--pythonpath PYTHONPATH] [--traceback] [--no-color]
                         [--force-color]
                         [app_label] [migration_name]
manage.py migrate: error: unrecognized arguments: --list
```

The updated `showmigrations` command below listed the migrations, as expected:

```
root@f0970eff4823:/site/proj# python manage.py showmigrations
admin
 [X] 0001_initial
 [X] 0002_logentry_remove_auto_add
 [X] 0003_logentry_add_action_flag_choices
announcements
 [X] 0001_initial
 [X] 0002_announcement_end_date
...