### PR TITLE
Change column behavior so that 'featured sponsor' section stacks on top of 'next event' section

### DIFF
--- a/chipy_org/templates/shiny/homepage.html
+++ b/chipy_org/templates/shiny/homepage.html
@@ -24,7 +24,12 @@
     </div>
 </div> <!--closes fullscreen background-->
 
-    <div class="row">
+    <div class="row flex-md-row-reverse">
+
+        <div class="col-md-6 my-4 px-5 py-3">
+            {% include "shiny/_featured_sponsor.html" %}
+        </div> <!--closes column-->
+
         <div class="col-md-6 my-4 px-5 pb-3" style="padding-top: 2.15rem">
                 {% if next_meeting.title %}
                     <h3 id="next-event">NEXT EVENT: {{ next_meeting.title | upper }}</h3>
@@ -75,10 +80,6 @@
                     {% include "shiny/_rsvp.html" with curr_meeting=next_meeting %}
                 {% endif %}
         </div> <!--closes column-->
-        <div class="col-md-6 my-4 px-5 py-3">
-                    {% include "shiny/_featured_sponsor.html" %}
-        </div> <!--closes column-->
-
 
     </div> <!--closes row-->
     {% with topic_count=next_meeting.topics.active.count %}

--- a/chipy_org/templates/shiny/site_base.html
+++ b/chipy_org/templates/shiny/site_base.html
@@ -38,7 +38,7 @@
                 <a class="icon-link" href="https://twitter.com/chicagopython"><img src="{% static 'img/svg/social-icons-twitter.svg' %}" target="_blank" rel="noopener noreferrer" class="my-2 mx-1" alt="Twitter Icon" height="35" width="35"></a>
                 <a class="icon-link" href="https://joinchipyslack.herokuapp.com/" target="_blank" rel="noopener noreferrer"> <img src="{% static 'img/svg/social-icons-slack.svg' %}" class="my-2 mx-1" alt="Slack Icon" height="35" width="35"></a>
                 <a class="icon-link" href="https://github.com/chicagopython/chipy.org" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-github.svg' %}" class="my-2 mx-1" alt="Github Icon" height="35" width="35"></a>
-                <a class="icon-link" href="https://www.meetup.com/_ChiPy_/" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-meetup.svg' %}" class="my-2 mx-1" alt="Github Icon" height="40" width="35"></a>
+                <a class="icon-link" href="https://www.meetup.com/_ChiPy_/" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-meetup.svg' %}" class="my-2 mx-1" alt="Github Icon" height="35" width="35"></a>
             </div>
 
             <div class="col-md-5">


### PR DESCRIPTION
-In homepage, change column behavior so that 'featured sponsor' section stacks on top of 'next event' section in tablet and mobile mode

-Fix icon size in footer