### PR TITLE
Link logos to homepage

### DIFF
--- a/chipy_org/templates/shiny/site_base.html
+++ b/chipy_org/templates/shiny/site_base.html
@@ -29,7 +29,9 @@
             <!--LOGO SECTION STARTS-->
             <div class="container-fluid">
                 <div class="logo-header p-4">
+                  <a href="/">
                     <img id="chicago-python-logo" src="{% static 'img/chicago-python-logo.png' %}" class="mx-auto d-block" alt="Chicago Python User Group Logo">
+                  </a>
                 </div>
             </div>
             <!--LOGO SECTION ENDS-->
@@ -58,7 +60,7 @@
                 <div class="container-xl">
                     <div id="footer" class="row py-4 px-5">
                         <div class="col-md-3">
-                            <img src="{% static 'img/chipy-logo.png' %}" class="pb-2" alt="Chipy: Chicago Python User Group Logo" height="37"><br>
+                          <a href="/"><img src="{% static 'img/chipy-logo.png' %}" class="pb-2" alt="Chipy: Chicago Python User Group Logo" height="37"></a><br>
                             A product of the <br>
                             Chicago Python User Group<br>
                             <a class="icon-link" href="https://www.youtube.com/channel/UCT372EAC1orBOSUd2fsA8WA" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-youtube-2.svg' %}" class="my-2 me-1" alt="Youtube Icon" height="35" width="35"></a>


### PR DESCRIPTION
## Problem

There's no way to get to the plain-old homepage.

## Solution

This adds links to both the header logo and the footer logo.