### PR TITLE
Dismiss messages fix 

### DIFF
--- a/chipy_org/templates/_messages.html
+++ b/chipy_org/templates/_messages.html
@@ -1,6 +1,6 @@
 {% for message in messages %}
-    <div class="alert {% if message.tags %} {% for tag in message.tags.split %}alert-{{ tag }} {% endfor %}{% endif %}">
-        <a class="close" href="#" data-dismiss="alert">&times;</a>
+    <div class="alert alert-dismissible {% if message.tags %} {% for tag in message.tags.split %}alert-{{ tag }} {% endfor %}{% endif %} fade show">
+        <a class="close" href="#" data-bs-dismiss="alert" aria-label="Close">&times;</a>
         {{ message|linebreaks }}
     </div>
 {% endfor %}


### PR DESCRIPTION
Fix to dismiss the messages #363 

The attribute "data-dismiss" is changed to "data-bs-dismiss" in Bootstrap 5. Please refer the link below for more info
https://getbootstrap.com/docs/5.0/components/alerts/#dismissing