### PR TITLE
Fix logo spacing and topic section spacing on homepage

### DIFF
--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -41,7 +41,7 @@
 <div class="container-xl">
     <div class="row flex-md-row-reverse">
 
-        <div class="col-lg-6 mt-4 px-5 pt-3">
+        <div class="col-lg-6 my-4 px-5 pt-3">
             {% include "shiny/_featured_sponsor.html" %}
         </div> <!--closes column-->
 
@@ -107,7 +107,7 @@
 {% with topic_count=next_meeting.topics.active.count %}
 {% if topic_count > 0 %}
 <div class="container-xl">
-    <div class="row my-0 py-3">
+    <div class="row my-0 pb-3">
         <div class="col-12 px-5">
             <h3>TOPICS FOR NEXT EVENT</h3>
         </div>

--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -115,7 +115,7 @@
     <div class="row">
 
         {% for topic in next_meeting.topics.active %}
-            <div class="col-lg{% if topic_count > 3%}-4{%endif%} px-5">
+            <div class="col-lg{% if topic_count > 3%}-4{%endif%} px-5 pb-2">
                 <h5 class="black-text">{{ topic.title }}</h5>
                 <div>
                     <strong>By:</strong>


### PR DESCRIPTION
Fix issue #388 

On homepage,
-Put a space under the sponsor logo 
-Fix other spacing issue with topic section