### PR TITLE
Updated job post agreement re: referral terms (Issue #387)

### DIFF
--- a/chipy_org/apps/job_board/templates/job_board/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_board/job_post_form.html
@@ -28,7 +28,7 @@
                 <tr>
                     <td colspan="2">
                     {{field}}
-                    I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>, which includes giving a referral fee when a candidate is hired/placed.
+                    I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>, which states that job posts are FREE for existing and new ChiPy sponsors, or are a $50 donation per eligible posting.
                     {{ field.errors }}
                     </td>
                 </tr>


### PR DESCRIPTION
Possible suggestion for slight grammar / clarity adjustments:

```diff
-"...the referral terms, which [states] that job posts are FREE for existing and new ChiPy sponsors, or [are] a $50 donation per eligible posting."

+"...the referral terms, which [state] that job posts are FREE for existing and new ChiPy sponsors, or [require] a $50 donation per eligible posting."
```

Not sure what happened with Ln#113 showing a change! Newline difference?