### PR TITLE
Fix so that email will be sent to chipy organizers when job post is created

### DIFF
--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -61,6 +61,8 @@ MANAGERS = ADMINS
 
 CHIPY_TOPIC_SUBMIT_EMAILS = env_var("CHIPY_TOPIC_SUBMIT_EMAILS", "").split(",")
 
+CHICAGO_ORGANIZER_EMAILS = env_var("CHICAGO_ORGANIZER_EMAILS", "").split(",")
+
 # dj_database_url will pull from the DATABASE_URL environment variable
 DATABASES = {"default": dj_database_url.config(default="postgres://localhost:5432/chipy_org")}
 


### PR DESCRIPTION
Add chicago_organizer_emails variable to settings.py . It previously was missing this.


