### PR TITLE
Fix modals on job_post_form and after_submit_job_post so that they show up on Bootstrap 5

### DIFF
--- a/chipy_org/apps/job_board/templates/job_board/after_submit_job_post.html
+++ b/chipy_org/apps/job_board/templates/job_board/after_submit_job_post.html
@@ -46,7 +46,7 @@
                     </td>
                 {% elif post.status == "RE" %}
                     <td>
-                        <button data-toggle="modal" data-target="#moreInfoModal" class="btn btn-info">More Info</button>
+                        <button data-bs-toggle="modal" data-bs-target="#moreInfoModal" class="btn btn-info">More Info</button>
                     </td>
                 {% endif %}
                 
@@ -95,7 +95,7 @@
             <div class="modal-header">
                 <h5 class="modal-title" id="moreInfoModalLabel">More Info</h5>
           
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
@@ -106,7 +106,7 @@
             </div>
 
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
             </div>
 
         </div>

--- a/chipy_org/apps/job_board/templates/job_board/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_board/job_post_form.html
@@ -40,7 +40,7 @@
                 <tr>
                     <td>&nbsp;</td>
                     <td>
-                        ChiPy is a locally based group. <button data-toggle="modal" data-target="#moreInfoModal" class="btn btn-info">more</buttondata-toggle="modal" data-target="#moreInfoModal" class="btn btn-info" >
+                        ChiPy is a locally based group. <button data-bs-toggle="modal" data-bs-target="#moreInfoModal" class="btn btn-info">more</button>
                         {{ field.errors }}
                     </td>
                 </tr>
@@ -92,7 +92,7 @@
             <div class="modal-header">
                 <h5 class="modal-title" id="moreInfoModalLabel">Location Requirements for Job Posting</h5>
           
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
@@ -102,7 +102,7 @@
             </div>
 
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
             </div>
 
         </div>


### PR DESCRIPTION
Fixes issue #365 

Since upgrading to Bootstrap 5 during the redesign, the modals on the job_post_form and after_submit_job_post were not working. This PR fixes both modals. 