### PR TITLE
Add callout for requiring docker+make

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Make the project directory your working directory:
 
     cd chipy.org
 
+**Note: The `make` commands require Make to be installed, and Docker must be running. Please follow the [Installation](#installation) guide before running the below steps**
+
 Run the setup command to configure the environment. This will copy
 a default configuration file from docker/docker.env.sample to
 docker/docker.env.


### PR DESCRIPTION
Resolves #383 by adding a callout to note that Make and Docker must be installed first, and Docker must be running