### PR TITLE
Standardize past meeting paginate

### DIFF
--- a/chipy_org/apps/main/views.py
+++ b/chipy_org/apps/main/views.py
@@ -18,8 +18,7 @@ class Home(TemplateView, InitialRSVPMixin):
 
     def get_meeting(self):
         return (
-            Meeting.objects
-            .filter(when__gt=datetime.datetime.now() - datetime.timedelta(hours=6))
+            Meeting.objects.filter(when__gt=datetime.datetime.now() - datetime.timedelta(hours=6))
             .order_by("when")
             .first()
         )

--- a/chipy_org/apps/meetings/templates/meetings/past_meetings.html
+++ b/chipy_org/apps/meetings/templates/meetings/past_meetings.html
@@ -70,25 +70,27 @@
 {% endfor %}
 
 
-{% if is_paginated %}
-  <ul class="pagination" style='display:flex;justify-content:center;'>
-    {% if page_obj.has_previous %}
-      <li style='margin-left:10px;'><a href="?page={{ page_obj.previous_page_number }}"> &laquo; </a></li>
-    {% else %}
-      <li class="disabled" style='margin-left:10px;'> <span> &laquo; </span> </li>
-    {% endif %}
-    {% for i in paginator.page_range %}
-      {% if page_obj.number == i %}
-        <li class="active" style='margin-left:10px;'><span> {{ i }} </span></li>
+<nav aria-label="Page navigation">
+  <ul class="pagination">
+      {% if page_obj.has_previous %}
+          <li class="page-item"><a class="page-link" href="?page=1">&laquo;</a></li>
+          <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">&lt;</a></li>
       {% else %}
-        <li style='margin-left:10px;'><a href="?page={{ i }}"> {{ i }} </a></li>
+          <li class="page-item disabled"><a class="page-link" >&laquo;</a></li>
+          <li class="page-item disabled"><a class="page-link">&lt;</a></li>
       {% endif %}
-    {% endfor %}
-    {% if page_obj.has_next %}
-      <li style='margin-left:10px;'><a href="?page={{ page_obj.next_page_number }}"> &raquo;</a> </li>
-    {% else %}
-      <li class="disabled" style='margin-left:10px;'><span>&raquo;</span></li>
-    {% endif %}
+
+      <li class="page-item">
+          <a class="page-link" style="color: black; background-color: white;">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</a>
+      </li>
+
+      {% if page_obj.has_next %}
+          <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">&gt;</a>
+          <li class="page-item"></li><a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">&raquo;</a>
+      {% else %}
+          <li class="page-item disabled"><a class="page-link" >&gt;</a>
+          <li class="page-item disabled"><a class="page-link">&raquo;</a></li>
+      {% endif %}
   </ul>
-{% endif %}
+</nav>
 {% endblock body %}

--- a/chipy_org/dev_utils/management/commands/makedevdata.py
+++ b/chipy_org/dev_utils/management/commands/makedevdata.py
@@ -1,4 +1,6 @@
+import random
 import sys
+import uuid
 from datetime import datetime, timedelta
 
 from django.conf import settings
@@ -35,7 +37,7 @@ class Command(BaseCommand):
             )
             page.sites.add(site)
 
-        # add user
+        # Add a user
         tyler, _ = User.objects.get_or_create(
             username="tdurden",
             first_name="tyler",
@@ -50,7 +52,7 @@ class Command(BaseCommand):
             email="narrator@paperstreet.com",
         )
 
-        # announcement data
+        # Announcements
         for announcement in announcements.models.Announcement.objects.filter(
             headline__startswith="Dev"
         ):
@@ -61,7 +63,7 @@ class Command(BaseCommand):
                 headline=f"Dev Headline - {k}", text="Dev Announcement", active=True, end_date=v,
             )
 
-        # meetings data
+        # Meetings
         presenter, _ = meetings.models.Presenter.objects.get_or_create(
             user=tyler,
             name=tyler.first_name + " " + tyler.last_name,
@@ -101,6 +103,23 @@ class Command(BaseCommand):
 
             count += 1
 
+        # Add a bunch of past meetings too for pagination testing
+        for _ in range(10):
+            meeting_id = str(uuid.uuid4())
+            random_days_ago = random.randint(10, 30)
+            meeting_date = now - timedelta(days=random_days_ago)
+            meeting_description = f"Dev meeting{random.randint(1000, 2000)}"
+            meeting_registration_end = meeting_date + timedelta(days=6)
+
+            meeting, _ = meetings.models.Meeting.objects.update_or_create(
+                where=venue,
+                when=meeting_date,
+                description=meeting_description,
+                reg_close_date=meeting_registration_end,
+                key=meeting_id,
+            )
+
+        # Jobs
         for job in job_board.models.JobPost.objects.filter(position__startswith="DEV DATA"):
             job.delete()
 
@@ -134,7 +153,7 @@ class Command(BaseCommand):
         )
         job_post.approve()
 
-        # make some sponsors
+        # Sponsors
         sponsor_levels = [("Platinum", 1), ("Gold", 2), ("Silver", 3), ("Bronze", 4)]
         sponsor_groups = dict()
 


### PR DESCRIPTION
Resolves #364

I copied over the pagination view from the job board to the past meeting view, and I also updated the `makedevdata.py` script to add a healthy amount of past meetings to view the pagination at work.

![First page](https://user-images.githubusercontent.com/5069012/114965903-2836c500-9e37-11eb-8ffa-aa9efe1dea92.png)
![Second page](https://user-images.githubusercontent.com/5069012/114965905-2a008880-9e37-11eb-82a1-9bbd9c21f003.png)
