### PR TITLE
Add img alt texts where missing

### DIFF
--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -150,7 +150,7 @@
                     <div class="col py-2 px-2">
                         <div>
                             <a href="https://github.com/chicagopython/chipy.org" target="_blank" rel="noopener noreferrer">
-                                <img class="join-us-icon" src="{% static 'icons/github-square-social-media.svg' %}"/>
+                                <img class="join-us-icon" src="{% static 'icons/github-square-social-media.svg' %}" alt="GitHub logo"/>
                             </a>
                         </div>
                         <div class="text-center d-none d-md-block ">Collaborate on Code!</div>
@@ -158,7 +158,7 @@
                     <div class="col py-2 px-2">
                         <div class="text-center">
                             <a href="https://joinchipyslack.herokuapp.com/" target="_blank" rel="noopener noreferrer">
-                                <img class="join-us-icon" src="{% static 'icons/slack-square-social-media.svg' %}"/>
+                                <img class="join-us-icon" src="{% static 'icons/slack-square-social-media.svg' %}" alt="Slack logo"/>
                             </a>
                         </div>
                         <div class="text-center d-none d-md-block">Chat on Slack!</div>
@@ -166,7 +166,7 @@
                     <div class="col py-2 px-2">
                         <div>
                             <a id="icon-meetup" href="https://www.meetup.com/_ChiPy_/" target="_blank" rel="noopener noreferrer">
-                                <img class="join-us-icon" src="{% static 'icons/meetup-logo.svg' %}"/>
+                                <img class="join-us-icon" src="{% static 'icons/meetup-logo.svg' %}" alt="Meetup logo"/>
                             </a>
                         </div>
                         <div class="text-center d-none d-md-block">Events on Meetup!</div>
@@ -174,7 +174,7 @@
                     <div class="col py-2 px-2">
                         <div>
                             <a id="icon-twitter" href="https://twitter.com/chicagopython" target="_blank" rel="noopener noreferrer">
-                                <img class="join-us-icon" src="{% static 'icons/twitter-square-social-media.svg' %}">
+                                <img class="join-us-icon" src="{% static 'icons/twitter-square-social-media.svg' %}" alt="Twitter logo">
                             </a>
                         </div>
                             <div class="text-center d-none d-md-block">Check out our Tweets!</div>
@@ -182,7 +182,7 @@
                     <div class="col py-2 px-2">
                         <div>
                             <a id="icon-youtube" href="https://www.youtube.com/channel/UCT372EAC1orBOSUd2fsA8WA" target="_blank" rel="noopener noreferrer">
-                                <img class="join-us-icon" src="{% static 'icons/youtube-logo.svg' %}">
+                                <img class="join-us-icon" src="{% static 'icons/youtube-logo.svg' %}" alt="YouTube logo">
                             </a>
                         </div>
                         <div>
@@ -208,7 +208,7 @@
             <img src="{% static 'img/lt@3x-cropped.jpg' %}" alt="Happy ChiPy people" height="250" >
         </div>
         <div class="col-lg text-center pe-lg-5">
-            <img src="{% static 'img/rt@3x.jpg' %}" alt="ChiPy Attendees working on projects together" height="250" >
+            <img src="{% static 'img/rt@3x.jpg' %}" alt="ChiPy attendees working on projects together" height="250" >
         </div>
     </div>
 </div><!--closes container-->

--- a/chipy_org/templates/shiny/site_base.html
+++ b/chipy_org/templates/shiny/site_base.html
@@ -16,11 +16,11 @@
         <!--Material Design Icons-->
         <!--See https://google.github.io/material-design-icons/ for documentation-->
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-        
+
         <link rel="stylesheet" href="{% static 'css/shiny.css' %}">
-        
-        {{ form.media }}        
-        
+
+        {{ form.media }}
+
         {% block extra_head %}{% endblock %}
 
         <title>Chicago Python User Group</title>
@@ -48,7 +48,7 @@
             <!--BACKGROUND PIC HEADER SECTION ENDS-->
 
         </header>
-        
+
         <main>
 
             <!--CONTENT SECTION STARTS-->
@@ -70,7 +70,7 @@
                             <a class="icon-link" href="https://twitter.com/chicagopython"><img src="{% static 'img/svg/social-icons-twitter.svg' %}" target="_blank" rel="noopener noreferrer" class="my-2 mx-1" alt="Twitter Icon" height="35" width="35"></a>
                             <a class="icon-link" href="https://joinchipyslack.herokuapp.com/" target="_blank" rel="noopener noreferrer"> <img src="{% static 'img/svg/social-icons-slack.svg' %}" class="my-2 mx-1" alt="Slack Icon" height="35" width="35"></a>
                             <a class="icon-link" href="https://github.com/chicagopython/chipy.org" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-github.svg' %}" class="my-2 mx-1" alt="Github Icon" height="35" width="35"></a>
-                            <a class="icon-link" href="https://www.meetup.com/_ChiPy_/" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-meetup.svg' %}" class="my-2 mx-1" alt="Github Icon" height="35" width="35"></a>
+                            <a class="icon-link" href="https://www.meetup.com/_ChiPy_/" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-meetup.svg' %}" class="my-2 mx-1" alt="Meetup Icon" height="35" width="35"></a>
                         </div>
 
                         <div class="col-md-5">
@@ -118,9 +118,9 @@
 
         <!--JAVASCRIPT FOR Sticky Navbar STARTS -->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-        
+
         <script>
-        
+
             $(function () {
               $(document).scroll(function () {
                 var $nav = $(".nav-sticky-top");


### PR DESCRIPTION
Resolves #354 in the areas requested:

- `/chipy_org/templates/shiny/homepage.html`: I couldn't find this homepage file, but I did find and update `/chipy_org/apps/main/templates/main/homepage.html`. The featured sponsors already have alt texts supplied [here](https://github.com/chicagopython/chipy.org/blob/3602409f87bd6b1304a29e3dd45648dd5f69130a/chipy_org/apps/main/templates/main/homepage.html#L45) and [here](https://github.com/chicagopython/chipy.org/blob/3602409f87bd6b1304a29e3dd45648dd5f69130a/chipy_org/templates/shiny/_featured_sponsor.html#L10-L12):

```html
<a href="{% url 'sponsor_detail' featured_sponsor.slug %}">
    <img src="{{ im.url }}" alt="{{ featured_sponsor.name }}">
</a>
```
I also verified this on chipy.org today for the current featured sponsor:

![image](https://user-images.githubusercontent.com/5069012/115130819-64456380-9fb8-11eb-8aa8-65e9e06d04f7.png)

- `/chipy_org/templates/shiny/site_base.html`: updated missing alt texts
- `/chipy_org/templates/shiny/slim.html`: I didn't find any missing alt texts on this page
