### PR TITLE
Changed wording in job post page and model to reflect new referral requirements verbage

### DIFF
--- a/chipy_org/apps/job_board/models.py
+++ b/chipy_org/apps/job_board/models.py
@@ -95,8 +95,11 @@ class JobPost(CommonModel):
     contact = models.ForeignKey(User, blank=True, null=True, on_delete=models.DO_NOTHING)
 
     agree_to_terms = models.BooleanField(
-        verbose_name="I have read and agree to the referral terms, "
-        "which includes giving a referral fee when a candidate is hired/placed."
+        verbose_name="I have read and agree to the referral terms. "
+        "Job posts are FREE for existing and new ChiPy sponsors. "
+        "If you are not a ChiPy sponsor, a job post REQUIRES a $50 DONATION to ChiPy"
+        " per eligible post. Job posts will not be approved to show up in the job board"
+        " if these requirements aren't met."
     )
 
     is_from_recruiting_agency = models.BooleanField(

--- a/chipy_org/apps/job_board/models.py
+++ b/chipy_org/apps/job_board/models.py
@@ -97,9 +97,7 @@ class JobPost(CommonModel):
     agree_to_terms = models.BooleanField(
         verbose_name="I have read and agree to the referral terms. "
         "Job posts are FREE for existing and new ChiPy sponsors. "
-        "If you are not a ChiPy sponsor, a job post REQUIRES a $50 DONATION to ChiPy"
-        " per eligible post. Job posts will not be approved to show up in the job board"
-        " if these requirements aren't met."
+        "If you are not a ChiPy sponsor, each job post REQUIRES a $50 DONATION."
     )
 
     is_from_recruiting_agency = models.BooleanField(

--- a/chipy_org/apps/job_board/templates/job_board/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_board/job_post_form.html
@@ -27,6 +27,11 @@
             {% if field == job_post_form.agree_to_terms %}
                 <tr>
                     <td colspan="2">
+                    <!--
+                        IMPORTANT: If you change the verbage below for this field, 
+                        you must also change the job_board/models.py, specifically the "verbose_name" in the "agree_to_terms" field, to make them have the same wording. 
+                        This is so the wording for this field in the admin panel can match the wording in this template.
+                    -->    
                     {{field}}
                     I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>. Job posts are <b>FREE for existing and new ChiPy sponsors</b>. If you are <b>not a ChiPy sponsor</b>, a job post <b>REQUIRES a $50 DONATION</b> to ChiPy per eligible post. Job posts will not be approved to show up in the job board if these requirements aren't met.
                     {{ field.errors }}

--- a/chipy_org/apps/job_board/templates/job_board/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_board/job_post_form.html
@@ -33,7 +33,7 @@
                         This is so the wording for this field in the admin panel can match the wording in this template.
                     -->    
                     {{field}}
-                    I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>. Job posts are <b>FREE for existing and new ChiPy sponsors</b>. If you are <b>not a ChiPy sponsor</b>, a job post <b>REQUIRES a $50 DONATION</b> to ChiPy per eligible post. Job posts will not be approved to show up in the job board if these requirements aren't met.
+                    I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>. Job posts are <b>FREE for existing and new ChiPy sponsors</b>. If you are <b>not a ChiPy sponsor</b>, each job post <b>REQUIRES a $50 DONATION</b>.
                     {{ field.errors }}
                     </td>
                 </tr>

--- a/chipy_org/apps/job_board/templates/job_board/job_post_form.html
+++ b/chipy_org/apps/job_board/templates/job_board/job_post_form.html
@@ -28,7 +28,7 @@
                 <tr>
                     <td colspan="2">
                     {{field}}
-                    I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>, which states that job posts are FREE for existing and new ChiPy sponsors, or are a $50 donation per eligible posting.
+                    I have read and agree to the <a href="/pages/referrals/" target="_blank">referral terms</a>. Job posts are <b>FREE for existing and new ChiPy sponsors</b>. If you are <b>not a ChiPy sponsor</b>, a job post <b>REQUIRES a $50 DONATION</b> to ChiPy per eligible post. Job posts will not be approved to show up in the job board if these requirements aren't met.
                     {{ field.errors }}
                     </td>
                 </tr>

--- a/chipy_org/apps/main/views.py
+++ b/chipy_org/apps/main/views.py
@@ -18,8 +18,7 @@ class Home(TemplateView, InitialRSVPMixin):
 
     def get_meeting(self):
         return (
-            Meeting.objects
-            .filter(when__gt=datetime.datetime.now() - datetime.timedelta(hours=6))
+            Meeting.objects.filter(when__gt=datetime.datetime.now() - datetime.timedelta(hours=6))
             .order_by("when")
             .first()
         )


### PR DESCRIPTION
Fixes #409 

I changed the verbage for the job post page and on the model (so that it shows up on the admin panel) to:

"I have read and agree to the referral terms. Job posts are FREE for existing and new ChiPy sponsors. If you are not a ChiPy sponsor, a job post REQUIRES a $50 DONATION to ChiPy per eligible post. Job posts will not be approved to show up in the job board if these requirements aren't met." 

The views.py page being committed has to do with the Black formatter formatting that page.