### PR TITLE
Add slack integration for job board

### DIFF
--- a/chipy_org/apps/job_board/forms.py
+++ b/chipy_org/apps/job_board/forms.py
@@ -29,7 +29,9 @@ class JobPostForm(forms.ModelForm):
         ]
 
         help_texts = {
-            "affiliation": ("Is this posting affiliated with a 3rd party? Please select:"),  # pylint: disable=line-too-long
+            "affiliation": (
+                "Is this posting affiliated with a 3rd party? Please select:"
+            ),  # pylint: disable=line-too-long
         }
 
         widgets = {

--- a/chipy_org/apps/job_board/forms.py
+++ b/chipy_org/apps/job_board/forms.py
@@ -29,9 +29,7 @@ class JobPostForm(forms.ModelForm):
         ]
 
         help_texts = {
-            "affiliation": (
-                "Is this posting affiliated with a 3rd party? Please select:"
-            ),  # pylint: disable=line-too-long
+            "affiliation": ("Is this posting affiliated with a 3rd party? Please select:"),
         }
 
         widgets = {

--- a/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
+++ b/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
@@ -21,7 +21,6 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-        print("These are the Active Postings on the Job Board", "\n")
         posts = JobPost.approved_and_active.all()
 
         if posts.count():

--- a/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
+++ b/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import requests
 from django.conf import settings
@@ -6,6 +7,8 @@ from django.core.management.base import BaseCommand
 from django.template import loader
 
 from chipy_org.apps.job_board.models import JobPost
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -36,8 +39,5 @@ class Command(BaseCommand):
                 headers={"Content-Type": "application/json"},
             )
 
-            if response.status_code == 200:
-                print("success")
-            else:
-                # do some logging
-                pass
+            if response.status_code != 200:
+                logger.info("Failed to post to slack job channel.")

--- a/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
+++ b/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
@@ -1,0 +1,43 @@
+import json
+
+import requests
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.template import loader
+
+from chipy_org.apps.job_board.models import JobPost
+
+
+class Command(BaseCommand):
+    help = """
+    This command retrieves all approved and active job posts from the database
+    and posts them to the slack jobs channel. 
+    
+    Integrate this command with a scheduler to automatically post jobs to the 
+    slack jobs channel.  
+    """
+
+    def handle(self, *args, **options):
+        print("These are the Active Postings on the Job Board", "\n")
+        posts = JobPost.approved_and_active.all()
+
+        if posts.count():
+            context = {"posts": posts}
+            template = loader.get_template("job_board/slack_template.txt")
+            msg = template.render(context)
+
+            job_post_key = settings.JOB_POST_KEY
+            webhook_url = f"https://hooks.slack.com/services/{job_post_key}"
+            slack_data = {"text": msg}
+
+            response = requests.post(
+                webhook_url,
+                data=json.dumps(slack_data),
+                headers={"Content-Type": "application/json"},
+            )
+
+            if response.status_code == 200:
+                print("success")
+            else:
+                # do some logging
+                pass

--- a/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
+++ b/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import datetime
 
 import requests
 from django.conf import settings
@@ -20,10 +21,21 @@ class Command(BaseCommand):
     slack jobs channel.  
     """
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "weekdays",
+            nargs="+",
+            type=int,
+            help="""
+            The desired weekdays to post represented an integer where Monday=0, Tuesday=1, ... , Saturday=5, and Sunday=6.
+            Posts to the slack channel will only occur on the selected weekdays.
+            """,
+        )
+
     def handle(self, *args, **options):
         posts = JobPost.approved_and_active.all()
 
-        if posts.count():
+        if posts.count() and datetime.date.today().weekday() in options["weekdays"]:
             context = {"posts": posts}
             template = loader.get_template("job_board/slack_template.txt")
             msg = template.render(context)

--- a/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
+++ b/chipy_org/apps/job_board/management/commands/post_approved_jobs_to_slack.py
@@ -1,10 +1,10 @@
+import datetime
 import json
 import logging
-import datetime
 
 import requests
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.template import loader
 
 from chipy_org.apps.job_board.models import JobPost
@@ -51,4 +51,6 @@ class Command(BaseCommand):
             )
 
             if response.status_code != 200:
-                logger.info("Failed to post to slack job channel.")
+                raise CommandError(
+                    f"Failed to post to slack job channel - status code: {response.status_code}."
+                )

--- a/chipy_org/apps/job_board/templates/job_board/slack_template.txt
+++ b/chipy_org/apps/job_board/templates/job_board/slack_template.txt
@@ -1,12 +1,11 @@
-
-The are currently {{ posts.count }} job{{ posts.count|pluralize }} on the Chipy job board
+There {{ posts.count|pluralize:"is,are" }} currently *{{ posts.count }}* job{{ posts.count|pluralize }} on the Chipy job board.
 
 {% for post in posts %}
-    {{post.company_name}} has a posting for a {{post.position}}.
-    
-    Description:
-    {{ post.description }}
+*{{ post.company_name }}* posted a *{{ post.position }}* opportunity.
+
+*Description*:
+{{ post.description }}
 
 {% endfor %}
 
-See all the posts on https://www.chipy.org/job-board/
+See all the open job posts on https://www.chipy.org/job-board/

--- a/chipy_org/apps/job_board/templates/job_board/slack_template.txt
+++ b/chipy_org/apps/job_board/templates/job_board/slack_template.txt
@@ -1,0 +1,12 @@
+
+The are currently {{ posts.count }} job{{ posts.count|pluralize }} on the Chipy job board
+
+{% for post in posts %}
+    {{post.company_name}} has a posting for a {{post.position}}.
+    
+    Description:
+    {{ post.description }}
+
+{% endfor %}
+
+See all the posts on https://www.chipy.org/job-board/

--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -111,6 +111,9 @@ if USE_S3:
 else:
     MEDIA_ROOT = os.path.abspath(os.path.join(PROJECT_ROOT, "mediafiles"))
 
+
+JOB_POST_KEY = env_var("JOB_POST_KEY", "")
+
 STATIC_ROOT = os.path.abspath(os.path.join(PROJECT_ROOT, "..", "staticfiles"))
 
 STATIC_URL = "/static/"

--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -127,7 +127,6 @@ MEDIA_URL = "/media/"
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = env_var("SECRET_KEY")
-DAY_TO_POST = int(env_var("DAY_TO_POST", 6))
 
 ROOT_URLCONF = "chipy_org.urls"
 

--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -114,6 +114,7 @@ else:
 
 JOB_POST_KEY = env_var("JOB_POST_KEY", "")
 
+
 STATIC_ROOT = os.path.abspath(os.path.join(PROJECT_ROOT, "..", "staticfiles"))
 
 STATIC_URL = "/static/"
@@ -126,7 +127,7 @@ MEDIA_URL = "/media/"
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = env_var("SECRET_KEY")
-
+DAY_TO_POST = int(env_var("DAY_TO_POST", 6))
 
 ROOT_URLCONF = "chipy_org.urls"
 

--- a/docker/docker.env.sample
+++ b/docker/docker.env.sample
@@ -83,3 +83,7 @@ EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend'
 #AWS_STORAGE_BUCKET_NAME=""
 #
 ################################################
+
+# Slack Webhooks ##########################################
+JOB_POST_KEY=""
+###########################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-ical==1.7.0
 django-nocaptcha-recaptcha==0.0.20
 django-storages==1.9.1
 django-tinymce==2.8.0
-Django==2.2.22
+Django==2.2.24
 djangorestframework==3.11.2
 feedparser==5.2.1
 gunicorn==20.0.4


### PR DESCRIPTION
This PR adds a custom Django command which can be scheduled to post the list of current approved jobs to slack.  Given we use Heroku I suggest we use their scheduler to post to the jobs channel daily in the early A.M.  Maybe 7AM?  