### PR TITLE
Contact Form Feedback as Modal Issue#357

### DIFF
--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -19,7 +19,9 @@
                     </table>
                     <div class="text-center">
                         <input class="btn btn-primary" type="submit" value="Send Email">
+                        <!-- <input class="btn btn-primary" type="submit" value="Send Email" data-bs-toggle="modal" data-bs-target="#contact-modal"> -->
                     </div>
+                    <div id="contact-modal-show" style="display:none" data-bs-toggle="modal" data-bs-target="#contact-modal"></div>
                   </form>
                 </div>
               </div>
@@ -35,7 +37,35 @@
           </div>
         </div>
     </div>
+    
+    {% if messages %}
+      <!-- CONTACT MODAL STARTS-->
+      <div class="modal fade" id="contact-modal" tabindex="-1" aria-labelledby="contactModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <img src="https://via.placeholder.com/150"></img>
+                    <h5 class="modal-title black-text" id="contactModalLabel">Thank You.</h5>
+                </div>
+                <div class="modal-body">
+                    {% include "_messages.html" %}
+                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal" aria-label="Close">Return to site</button>
+                </div>
+            </div>
+        </div>
+      </div>
+      <!-- CONTACT MODAL ENDS-->
+
+      <script>
+        window.addEventListener('load', function () {
+          document.querySelector("#contact-modal-show").click();
+        });
+      </script>
+
+    {% endif %}
 {% endblock %}
+
+
 
 {% block extra-javascript %}
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/chipy_org/apps/contact/views.py
+++ b/chipy_org/apps/contact/views.py
@@ -7,7 +7,7 @@ from chipy_org.apps.contact.forms import ContactForm
 class ContactView(FormView):
     template_name = "contact/contact.html"
     form_class = ContactForm
-    success_url = "/"
+    success_url = "/contact"
 
     def form_valid(self, form):
         try:

--- a/chipy_org/templates/_messages.html
+++ b/chipy_org/templates/_messages.html
@@ -1,6 +1,12 @@
 {% for message in messages %}
+    <div>{{ message|linebreaks }}</div>
+{% endfor %}
+
+<!-- ORIGINAL
+{% for message in messages %}
     <div class="alert alert-dismissible {% if message.tags %} {% for tag in message.tags.split %}alert-{{ tag }} {% endfor %}{% endif %} fade show">
         <a class="close" href="#" data-bs-dismiss="alert" aria-label="Close">&times;</a>
         {{ message|linebreaks }}
     </div>
 {% endfor %}
+-->

--- a/chipy_org/templates/shiny/slim.html
+++ b/chipy_org/templates/shiny/slim.html
@@ -17,6 +17,7 @@
 
 {% block content %}
 
+<!-- ORIGINAL
 {% if messages %}
 <div class="container-xl">
     <div class="row">
@@ -24,8 +25,9 @@
             {% include "_messages.html" %}
         </div>
     </div>
-</div><!--closes container xl-->
+</div> --><!--closes container xl--><!--
 {% endif %}
+-->
 
 <div class="container-xl">
     <div class="row">


### PR DESCRIPTION
Hello!

This PR is an in-progress implementation of [Issue #357](https://github.com/chicagopython/chipy.org/issues/357).

I think my implementation may be a little hacky, and I'm definitely open to an alternative solution! (I wanted to give it a go alone first to see if I could do it 😃 ). I'll explain my approach below.

_P.S. I write long... my bad. I went into detail b/c I wanted to make sure I understood / to talk myself through everything once more._

_Before the wall of text below, here are my questions:_
- How do you feel about the implementation?

- Where should the form and/or modal redirect?

>

---
## Demo:

https://user-images.githubusercontent.com/51402465/133325214-f0ee38b9-7b2a-4b0f-93d7-3c55108b5179.mp4

---
## What was the previous functionality?
Previously, submitting the contact form resulted in a redirect to the chipy.org homepage, where a success/fail message would be presented like so:

![previously](https://user-images.githubusercontent.com/51402465/133325914-ff5cf338-c021-42db-98f4-ae68d10ab67c.png)


## Redirect
In its current state, this PR updates chipy_org/apps/contact/views.py such that the form submission redirects to the /contact page instead of going back to the homepage. It felt a little surprising to me when I was taken back to home by the "Send" button without warning.

If you'd like to preserve the old behavior, I think it might feel good if:
1. The "Send" button submits the form and stays on /contact page
1. The modal appears showing feedback
1. The button to close the modal reads "Return to Home" and redirects accordingly

## How was the modal HTML built?
I found an existing modal implementation in use for the site's login functionality; the HTML is located in shiny/navbar.html, and the javascript for its behavior is found in static/js/pinax.modal.js (neither file has been modified).

Here is where I begin to get concerned about being a bit hacky -- I copy/pasted the HTML for the Login Modal into the apps/contact/templates/contact.html file, and made appropriate adjustments to its structure/data and classes.

## How was the modal behavior built?
I continued to use the `django.contrib.messages` framework that already existed:
- I removed the behavior in shiny/slim.html that displayed the original green/red box w/message
- {% include "_messages.html" %} is now accessed in contact.html, inside the modal body
- in _messages.html, the messages object is still looped through in an identical way as before, except without the logic that styles the box red/green depending on success/failure.
    - The "X" close button in messages.html file was removed, in favor of replacing it with the "Return to Site" button which now lives in contact.html as part of the modal structure.

### What triggers the modal to show?
In the original code (pinax.modal.js), the modal is set up to be triggered by clicking an element (adding bootstrap classes to an element that makes it trigger the modal functionality).

Since this feedback should be automatic and not the result of user clicks, I had a little workaround:
- Added an empty div with appropriate data classes and `display:none` hardcoded into the tag
- When user visits the page:
    - (jinja templating) If there is a message to show:
        - add modal HTML
        - (script tag) when the page finishes loading, .click() that empty div to trigger the modal.
