### PR TITLE
Responsive sponsor_detail logo

### DIFF
--- a/chipy_org/apps/sponsors/templates/sponsors/sponsor_detail.html
+++ b/chipy_org/apps/sponsors/templates/sponsors/sponsor_detail.html
@@ -11,7 +11,7 @@
 {% thumbnail sponsor.logo "400" crop="center" as im %}
   <div>
     <a href="{{ sponsor.url }}">
-    <img src="{{ im.url }}" alt="{{ sponsor.name }}"></a>
+    <img class="img-fluid" src="{{ im.url }}" alt="{{ sponsor.name }}"></a>
   </div>
 {% empty %}
   <div class="row">


### PR DESCRIPTION
Should resolve issue #427 

I went poking around in bootstrap and found a bs-class that will handle making the logo image responsive, documentation found [here](https://getbootstrap.com/docs/4.0/content/images/#responsive-images).

The localhost version of the site/db doesn't have logos to test upon, so I did a brief experiment on the live site with browser devtools. Adding the class `img-fluid` to the appropriate img tag in the sponsor_detail.html template made the image responsive and it seemed to scale correctly (tried for screen sizes up to 1920x1080).

Here's a little video:

https://user-images.githubusercontent.com/51402465/143141252-2104430c-df23-4b9a-aa04-5f78c1af2370.mp4


I'm not quite sure how to get a sample image into the dev db for testing it properly, or if that would be the correct route -- however I'm packing+moving house at the moment, and don't have the time yet to figure it out properly.

Anyway, this PR just adds the `img-fluid` class to the img tag in sponsor_detail.html

:)