### PR TITLE
Fix logo alignment for sponsor page

### DIFF
--- a/chipy_org/apps/sponsors/templates/sponsors/sponsor_list.html
+++ b/chipy_org/apps/sponsors/templates/sponsors/sponsor_list.html
@@ -18,26 +18,27 @@
         </div>
         <div class="col-md-4 px-1 pt-1 pb-3">
             {% for group in sponsor_groups %}
-                <div class="row py-3">
+                <div class="row pt-3 pb-1">
                     <h3 class="text-center">{{ group.name }}</h3>
+                </div>
                     {% for sponsor in group.sponsors.all %}
-                    <div class="col-md">
+                    
                         {% if sponsor.logo %}
                         {% thumbnail sponsor.logo "100" crop="center" as im %}
-                            <div class="sponsor-image text-center"  style="margin: auto">
+                            <div class="row py-2 sponsor-image text-center"  style="margin: auto">
                                 <a href="{% url 'sponsor_detail' sponsor.slug %}">
                                     <img src="{{ im.url }}" alt="{{ sponsor.name }}">
                                 </a>
                             </div>
                         {% endthumbnail %}
                         {% else %}
-                            <div class="sponsor-image text-center" style="margin: auto">
+                            <div class="row py-2 sponsor-image text-center" style="margin: auto">
                                 <a href="{% url 'sponsor_detail' sponsor.slug %}">{{ sponsor.name }}</a>
                             </div>
                         {% endif %}
-                    </div>
+                    
                     {% endfor %}
-               </div>
+               
             {% endfor %}
         </div>
     </div>


### PR DESCRIPTION
This PR addresses issue #464 
Fixed sponsor logo alignment on sponsor page by placing the logos, one logo per row. Also, changed the code for when there is not a logo for the company.

Please see picture below.

<img width="553" alt="logo-fix" src="https://user-images.githubusercontent.com/53249319/158299547-50d77726-b1d7-4f67-a32d-191cbf09fde6.PNG">

