### PR TITLE
Remove link to dead slack site

### DIFF
--- a/chipy_org/templates/shiny/site_base.html
+++ b/chipy_org/templates/shiny/site_base.html
@@ -68,7 +68,7 @@
                             Chicago Python User Group<br>
                             <a class="icon-link" href="https://www.youtube.com/channel/UCT372EAC1orBOSUd2fsA8WA" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-youtube-2.svg' %}" class="my-2 me-1" alt="Youtube Icon" height="35" width="35"></a>
                             <a class="icon-link" href="https://twitter.com/chicagopython"><img src="{% static 'img/svg/social-icons-twitter.svg' %}" target="_blank" rel="noopener noreferrer" class="my-2 mx-1" alt="Twitter Icon" height="35" width="35"></a>
-                            <a class="icon-link" href="https://joinchipyslack.herokuapp.com/" target="_blank" rel="noopener noreferrer"> <img src="{% static 'img/svg/social-icons-slack.svg' %}" class="my-2 mx-1" alt="Slack Icon" height="35" width="35"></a>
+                            <a class="icon-link" href="/pages/slack/" target="_blank" rel="noopener noreferrer"> <img src="{% static 'img/svg/social-icons-slack.svg' %}" class="my-2 mx-1" alt="Slack Icon" height="35" width="35"></a>
                             <a class="icon-link" href="https://github.com/chicagopython/chipy.org" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-github.svg' %}" class="my-2 mx-1" alt="Github Icon" height="35" width="35"></a>
                             <a class="icon-link" href="https://www.meetup.com/_ChiPy_/" target="_blank" rel="noopener noreferrer"><img src="{% static 'img/svg/social-icons-meetup.svg' %}" class="my-2 mx-1" alt="Meetup Icon" height="35" width="35"></a>
                         </div>


### PR DESCRIPTION
## Problem
We used to have a free herokuapp that was the source of much heartache
both before and after it went away. Fraudulent requests and .... no more
free heroku.

## Solution
We need to switch to doing referrals in meatspace to slack. The [page already
exists](https://www.chipy.org/pages/slack/), just link to that instead.
