### PR TITLE
Drop meeting selector from talk submission

### DIFF
--- a/chipy_org/apps/meetings/forms.py
+++ b/chipy_org/apps/meetings/forms.py
@@ -21,15 +21,11 @@ class TopicForm(forms.ModelForm):
         "length",
     )
 
-    meeting = forms.ModelChoiceField(
-        queryset=Meeting.objects.filter(when__gt=datetime.datetime.now())
-    )
     name = forms.CharField(label="Your Name", required=True)
     email = forms.EmailField(label="Your Email", required=True)
 
     def __init__(self, request, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["meeting"].required = False
         self.fields["description"].required = True
         self.fields["experience_level"].required = True
         self.fields["length"].required = True
@@ -50,7 +46,6 @@ class TopicForm(forms.ModelForm):
             "title",
             "name",
             "email",
-            "meeting",
             "length",
             "experience_level",
             "description",

--- a/chipy_org/apps/meetings/forms.py
+++ b/chipy_org/apps/meetings/forms.py
@@ -1,5 +1,3 @@
-import datetime
-
 from captcha.fields import CaptchaField
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
@@ -8,7 +6,7 @@ from django.urls import reverse
 
 from chipy_org.libs.custom_captcha import CustomCaptchaTextInput
 
-from .models import RSVP, Meeting, Presenter, Topic
+from .models import RSVP, Presenter, Topic
 
 
 class TopicForm(forms.ModelForm):


### PR DESCRIPTION
As a speaker at ChiPy I want to submit a talk proposal, but to which meeting?
Should I pick the next one? Should I leave it blank? Oh, there are two
listed...which is the right one?

All these questions are not things we want speakers thinking about. We want
them to submit a talk and move on! If they have specific concerns or
reservations they can add them in the private comments.

Down the road we may decide we need specific meetings for talks up front (e.g.
lightning talks), but the way to handle that is likely a customized URL
sharing, not letting the user pick from a dropdown.
