### PR TITLE
Replace hardcoded emails with configurable ones

### DIFF
--- a/chipy_org/apps/job_board/email.py
+++ b/chipy_org/apps/job_board/email.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.core.mail import send_mail
 
 logger = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ def send_email_to_admin_after_create_job_post(position, company, recipients):
             " Please review it for approval."
         )
 
-        from_email = "DoNotReply@chipy.org"
+        from_email = settings.DEFAULT_FROM_EMAIL
 
         to_email = recipients
 
@@ -37,7 +38,7 @@ def send_email_to_admin_after_user_deletes_job_post(position, company, recipient
             " You no longer have to review it."
         )
 
-        from_email = "DoNotReply@chipy.org"
+        from_email = settings.DEFAULT_FROM_EMAIL
 
         to_email = recipients
 

--- a/chipy_org/apps/meetings/email.py
+++ b/chipy_org/apps/meetings/email.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import get_template
@@ -13,7 +14,7 @@ def send_rsvp_email(rsvp):
         htmly = get_template("meetings/emails/rsvp_email.html")
         context = {"rsvp": rsvp, "site": Site.objects.get_current()}
         subject = "Chipy: Link to Change your RSVP"
-        from_email = "DoNotReply@chipy.org"
+        from_email = settings.DEFAULT_FROM_EMAIL
         text_content = plaintext.render(context)
         html_content = htmly.render(context)
         msg = EmailMultiAlternatives(subject, text_content, from_email, [rsvp.email])
@@ -29,7 +30,7 @@ def send_meeting_topic_submitted_email(topic, recipients):  # pylint: disable=in
         htmly = get_template("meetings/emails/meeting_topic_submitted.html")
         context = {"topic": topic, "site": Site.objects.get_current()}
         subject = "Chipy: New Meeting Topic Submitted"
-        from_email = "DoNotReply@chipy.org"
+        from_email = settings.DEFAULT_FROM_EMAIL
         text_content = plaintext.render(context)
         html_content = htmly.render(context)
         msg = EmailMultiAlternatives(subject, text_content, from_email, recipients)


### PR DESCRIPTION
We need to get email working again, but some of our emails are hardcoded to an address that doesn't work. Let's get them all using the existing setting.