### PR TITLE
Rewrite email sending to stop sending from variable sources

### DIFF
--- a/chipy_org/apps/contact/forms.py
+++ b/chipy_org/apps/contact/forms.py
@@ -5,9 +5,9 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 from django.conf import settings
-from django.core.mail import EmailMessage
 
 from chipy_org.libs.custom_captcha import CustomCaptchaTextInput
+from chipy_org.libs.email import send_email
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +32,9 @@ class ContactForm(forms.Form):
     captcha = CaptchaField(widget=CustomCaptchaTextInput)
 
     def send_email(self):
-        msg = EmailMessage(
+        send_email(
+            recipients=getattr(settings, "ENVELOPE_EMAIL_RECIPIENTS", []),
             subject=self.cleaned_data["subject"],
             body=self.cleaned_data["message"],
-            from_email=self.cleaned_data["email"],
-            to=getattr(settings, "ENVELOPE_EMAIL_RECIPIENTS", []),
             reply_to=[self.cleaned_data["email"]],
         )
-        msg.send()

--- a/chipy_org/apps/meetings/email.py
+++ b/chipy_org/apps/meetings/email.py
@@ -1,8 +1,6 @@
 import logging
 
-from django.conf import settings
 from django.contrib.sites.models import Site
-from django.core.mail import EmailMultiAlternatives
 from django.template.loader import get_template
 
 from chipy_org.libs.email import send_email

--- a/chipy_org/apps/meetings/email.py
+++ b/chipy_org/apps/meetings/email.py
@@ -5,36 +5,26 @@ from django.contrib.sites.models import Site
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import get_template
 
+from chipy_org.libs.email import send_email
+
 logger = logging.getLogger(__name__)
 
 
 def send_rsvp_email(rsvp):
-    try:
-        plaintext = get_template("meetings/emails/rsvp_email.txt")
-        htmly = get_template("meetings/emails/rsvp_email.html")
-        context = {"rsvp": rsvp, "site": Site.objects.get_current()}
-        subject = "Chipy: Link to Change your RSVP"
-        from_email = settings.DEFAULT_FROM_EMAIL
-        text_content = plaintext.render(context)
-        html_content = htmly.render(context)
-        msg = EmailMultiAlternatives(subject, text_content, from_email, [rsvp.email])
-        msg.attach_alternative(html_content, "text/html")
-        msg.send()
-    except Exception as e:
-        logger.exception(e)
+    plaintext = get_template("meetings/emails/rsvp_email.txt")
+    htmly = get_template("meetings/emails/rsvp_email.html")
+    context = {"rsvp": rsvp, "site": Site.objects.get_current()}
+    subject = "Chipy: Link to Change your RSVP"
+    text_content = plaintext.render(context)
+    html_content = htmly.render(context)
+    send_email(rsvp.email, subject, text_content, html_content, swallow_errors=True)
 
 
 def send_meeting_topic_submitted_email(topic, recipients):  # pylint: disable=invalid-name
-    try:
-        plaintext = get_template("meetings/emails/meeting_topic_submitted.txt")
-        htmly = get_template("meetings/emails/meeting_topic_submitted.html")
-        context = {"topic": topic, "site": Site.objects.get_current()}
-        subject = "Chipy: New Meeting Topic Submitted"
-        from_email = settings.DEFAULT_FROM_EMAIL
-        text_content = plaintext.render(context)
-        html_content = htmly.render(context)
-        msg = EmailMultiAlternatives(subject, text_content, from_email, recipients)
-        msg.attach_alternative(html_content, "text/html")
-        msg.send()
-    except Exception as e:
-        logger.exception(e)
+    plaintext = get_template("meetings/emails/meeting_topic_submitted.txt")
+    htmly = get_template("meetings/emails/meeting_topic_submitted.html")
+    context = {"topic": topic, "site": Site.objects.get_current()}
+    subject = "Chipy: New Meeting Topic Submitted"
+    text_content = plaintext.render(context)
+    html_content = htmly.render(context)
+    send_email(recipients, subject, text_content, html_content, swallow_errors=True)

--- a/chipy_org/libs/email.py
+++ b/chipy_org/libs/email.py
@@ -12,7 +12,9 @@ def enforce_list(value):
     return value
 
 
-def send_email(recipients, subject, body, html_body=None, reply_to=None, swallow_errors=False):
+def send_email(  # pylint: disable=too-many-arguments
+    recipients, subject, body, html_body=None, reply_to=None, swallow_errors=False
+):
     """Helper to standardize sending of email"""
     recipients = enforce_list(recipients)
     reply_to = enforce_list(reply_to or [])

--- a/chipy_org/libs/email.py
+++ b/chipy_org/libs/email.py
@@ -1,0 +1,38 @@
+import logging
+
+from django.conf import settings
+from django.core.mail import EmailMessage, EmailMultiAlternatives
+
+logger = logging.getLogger(__name__)
+
+
+def enforce_list(value):
+    if isinstance(value, str):
+        return [value]
+    return value
+
+
+def send_email(recipients, subject, body, html_body=None, reply_to=None, swallow_errors=False):
+    """Helper to standardize sending of email"""
+    recipients = enforce_list(recipients)
+    reply_to = enforce_list(reply_to or [])
+
+    params = {
+        "from_email": settings.DEFAULT_FROM_EMAIL,
+        "to": recipients,
+        "subject": subject,
+        "body": body,
+        "reply_to": enforce_list(reply_to or settings.DEFAULT_FROM_EMAIL),
+    }
+    if html_body:
+        message = EmailMultiAlternatives(**params)
+        message.attach_alternative(html_body, "text/html")
+    else:
+        message = EmailMessage(**params)
+
+    try:
+        message.send()
+    except Exception:
+        logger.exception("Error sending email with subject %s", subject)
+        if not swallow_errors:
+            raise


### PR DESCRIPTION
Sendgrid turned on authorized senders and the email address(es) we were using
stopped working. We set up a new email address to get this working, but we need
to remove every occurrence of setting the "from" email on the message, since we
are now locked in.

We had 3 different implementations using the low-level Django message interface
which meant email senders needed to know how email settings worked. This PR
moves us to a single implementation that obscures the from setting.
