### PR TITLE
expose speaker emails in the admin interface 

### DIFF
--- a/chipy_org/apps/meetings/admin.py
+++ b/chipy_org/apps/meetings/admin.py
@@ -94,7 +94,11 @@ class MeetingAdmin(admin.ModelAdmin):
         TopicInline,
         MeetingSponsorInline,
     ]
-    readonly_fields = ["created", "modified"]
+    readonly_fields = ["created", "modified", "presenter_mailboxes"]
+
+    @admin.display(description="Presenter Emails")
+    def presenter_mailboxes(self, obj):
+        return ', '.join(obj.get_presenter_mailboxes())
 
     @mark_safe
     def action(self, obj):


### PR DESCRIPTION
When trying to email speakers in the past, I've found it difficult to get their email addresses out of the admin interface. I usually have to view source on the speaker multi-select box on the meeting page in order to copy out their email addresses.

Instead, I added a new readonly field to the admin Meeting page with a list of email addresses in RFC 5322 "mailbox" format. This allows us to much more easily identify the emails of the speakers. 

Let me know what you think.