### PR TITLE
Added Metadata tags for meetup pages

### DIFF
--- a/chipy_org/apps/meetings/templates/meetings/meeting.html
+++ b/chipy_org/apps/meetings/templates/meetings/meeting.html
@@ -8,6 +8,15 @@
 
 {% block body_class %}home{% endblock %}
 
+{% block extra_head %}
+    <meta name="description" content="{{ meeting.description|bleach|safe }}">
+
+    <meta property="og:site_name" content="Chicago Python User Group (Chipy)" >
+    <meta property="og:title" content="{{ meeting.title|bleach|safe }}" >
+    <meta property="og:description" content="{{ meeting.description|bleach|safe }}" >
+    <meta property="og:image" content="https://avatars.githubusercontent.com/u/1745975?s=800" >
+{% endblock %}
+
 {% block body %}
 <div itemscope itemtype="http://schema.org/Event">
 


### PR DESCRIPTION
Hello I noticed a problem when I was trying to promote my talk. There are no tags for metadata for social meta.

So I have tried to fix that.