### PR TITLE
Improve meeting layout

### DIFF
--- a/chipy_org/apps/meetings/templates/meetings/meeting.html
+++ b/chipy_org/apps/meetings/templates/meetings/meeting.html
@@ -28,7 +28,7 @@
             <a id="where-link" href="#"> {{ meeting.where|default:'N/A'}}</a>
           </p>
 
-          {% if meeting.where %}
+          {% if meeting.where and meeting.is_future %}
 
               {% if meeting.where.directions %}
               <p><strong>Directions:</strong></p>

--- a/chipy_org/apps/meetings/templates/meetings/meeting.html
+++ b/chipy_org/apps/meetings/templates/meetings/meeting.html
@@ -37,9 +37,6 @@
 
               <p>
                 {{ meeting.where.address }}<br>
-                {% if meeting.where.directions %}
-                  {{ meeting.where.directions }}<br>
-                {% endif %}
                 {% if meeting.where.phone %}
                   {{ meeting.where.phone }}<br>
                 {% endif %}

--- a/chipy_org/apps/meetings/templates/meetings/meeting.html
+++ b/chipy_org/apps/meetings/templates/meetings/meeting.html
@@ -51,6 +51,7 @@
       </div>
 
   </div>
+  {% if meeting.topics.active %}
   <div class="row-fluid">
 
       <div class="module span12">
@@ -76,6 +77,7 @@
        </div>
 
     </div><!-- #row-fluid -->
+    {% endif %}
 
 </div>
 

--- a/chipy_org/templates/shiny/_rsvp.html
+++ b/chipy_org/templates/shiny/_rsvp.html
@@ -3,19 +3,20 @@
 
 
 <div>
-    <strong>RSVPs</strong>
     {% if curr_meeting.can_register %}
+      <strong>RSVPs</strong>
         {% if curr_meeting.reg_close_date  %}
             <p style="color: red">Registration for this event will close on
                 {{ curr_meeting.reg_close_date|date:"l F j" }} at
                 {{ curr_meeting.reg_close_date|date:"g:i a" }}
             </p>
         {% endif %}
-    {% else %}
+    {% elif curr_meeting.is_future %}
+      <strong>RSVPs</strong>
         <p style="color: red">This event is no longer accepting registrations.</p>
     {% endif %}
     <p>
-        <strong>Current Attendance:</strong><br />
+        <strong>{% if curr_meeting_is_future %}Current {% endif%}Attendance:</strong><br />
         {% if next_meeting.is_in_person %}
         In Person Pythonistas: {{ next_meeting.number_in_person_rsvps}}<br />
         {% endif %}
@@ -25,7 +26,7 @@
     </p>
 
     <div>
-        {% if request.user.is_authenticated %}
+        {% if request.user.is_authenticated and curr_meeting.is_future %}
             {% if rsvp %}
                 You have RSVP'd <strong>{{ rsvp.get_response_display | upper }}</strong>
                 {% if curr_meeting.can_register %}


### PR DESCRIPTION
Couple of minor tasks to make meetings look nicer.

- Remove duplicative direction
- Don't show location details if meeting in the past
- Stop showing RSVP details on past meetings
- Don't show the meeting topics display if we have no topics



# Before

<img width="648" alt="Screenshot 2024-03-09 at 4 56 40 PM" src="https://github.com/chicagopython/chipy.org/assets/5155488/75620b1e-198a-4b8a-894e-25c72911b1e2">