### PR TITLE
Use django recaptcha instead of simple recaptcha

### DIFF
--- a/chipy_org/apps/contact/forms.py
+++ b/chipy_org/apps/contact/forms.py
@@ -1,19 +1,15 @@
 import logging
 
-from captcha.fields import CaptchaField
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 from django.conf import settings
+from django_recaptcha.fields import ReCaptchaField
 
-from chipy_org.libs.custom_captcha import CustomCaptchaTextInput
+from chipy_org.libs.custom_captcha import CrispyReCaptchaV2Checkbox
 from chipy_org.libs.email import send_email
 
 logger = logging.getLogger(__name__)
-
-
-# class CustomCaptchaTextInput(CaptchaTextInput):
-#     template_name = "contact/custom_field.html"
 
 
 class ContactForm(forms.Form):
@@ -21,6 +17,7 @@ class ContactForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.add_input(Submit("submit", "Send Email"))
+        self.fields["captcha"].label = False
 
     sender = forms.CharField(max_length=256, label="From")
     email = forms.EmailField(max_length=256)
@@ -29,7 +26,7 @@ class ContactForm(forms.Form):
         max_length=2000,
         widget=forms.Textarea(attrs=dict(cols=19, rows=10, placeholder="2000 character limit")),
     )
-    captcha = CaptchaField(widget=CustomCaptchaTextInput)
+    captcha = ReCaptchaField(widget=CrispyReCaptchaV2Checkbox, label="")
 
     def send_email(self):
         send_email(

--- a/chipy_org/apps/contact/tests.py
+++ b/chipy_org/apps/contact/tests.py
@@ -1,22 +1,29 @@
 import pytest
-from django.conf import global_settings
 from django.core import mail
-from django.test import override_settings
-
 from .forms import ContactForm
 
 
+from unittest.mock import patch
+
+from django_recaptcha.client import RecaptchaResponse
+
+@pytest.fixture
+def mocked_captcha():
+    mocked_submit = patch("django_recaptcha.fields.client.submit")
+    mocked_submit.return_value = RecaptchaResponse(is_valid=True)
+    yield
+
+
 @pytest.mark.django_db
-def test_chipy_contact_form():  # pylint: disable=redefined-outer-name
+def test_chipy_contact_form(mocked_captcha):  # pylint: disable=redefined-outer-name
     assert len(mail.outbox) == 0
 
     form_data = {
         "email": "test@test.com",
+        "g-recaptcha-response": "PASSED",
         "message": "test message",
         "sender": "test",
         "subject": "test subject",
-        "captcha_0": "dummy",
-        "captcha_1": "PASSED",
     }
 
     form = ContactForm(form_data)
@@ -26,7 +33,6 @@ def test_chipy_contact_form():  # pylint: disable=redefined-outer-name
     assert len(mail.outbox) == 1
 
 
-@pytest.mark.django_db
 def test_chipy_contact_view(client):  # pylint: disable=redefined-outer-name
     assert len(mail.outbox) == 0
 
@@ -37,8 +43,6 @@ def test_chipy_contact_view(client):  # pylint: disable=redefined-outer-name
             "message": "test message",
             "sender": "test",
             "subject": "test subject",
-            "captcha_0": "dummy",
-            "captcha_1": "PASSED",
         },
         follow=True,
     )

--- a/chipy_org/apps/contact/tests.py
+++ b/chipy_org/apps/contact/tests.py
@@ -1,11 +1,11 @@
-import pytest
-from django.core import mail
-from .forms import ContactForm
-
-
 from unittest.mock import patch
 
+import pytest
+from django.core import mail
 from django_recaptcha.client import RecaptchaResponse
+
+from .forms import ContactForm
+
 
 @pytest.fixture
 def mocked_captcha():
@@ -47,7 +47,6 @@ def test_chipy_contact_view(client):  # pylint: disable=redefined-outer-name
         follow=True,
     )
     assert response.status_code == 200
-
 
 #    assert b"Your message has been sent to" in response.content
 #    assert len(mail.outbox) == 1

--- a/chipy_org/apps/meetings/forms.py
+++ b/chipy_org/apps/meetings/forms.py
@@ -1,11 +1,10 @@
-from captcha.fields import CaptchaField
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 from django.urls import reverse
+from django_recaptcha.fields import ReCaptchaField
 
-from chipy_org.libs.custom_captcha import CustomCaptchaTextInput
-
+from chipy_org.libs.custom_captcha import CrispyReCaptchaV2Checkbox
 from .models import RSVP
 
 
@@ -64,4 +63,4 @@ class RSVPForm(forms.ModelForm):
 
 
 class RSVPFormWithCaptcha(RSVPForm):
-    captcha = CaptchaField(widget=CustomCaptchaTextInput)
+    captcha = ReCaptchaField(widget=CrispyReCaptchaV2Checkbox, label="")

--- a/chipy_org/apps/meetings/forms.py
+++ b/chipy_org/apps/meetings/forms.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django_recaptcha.fields import ReCaptchaField
 
 from chipy_org.libs.custom_captcha import CrispyReCaptchaV2Checkbox
+
 from .models import RSVP
 
 

--- a/chipy_org/apps/meetings/templates/meetings/_rsvp_form_response.html
+++ b/chipy_org/apps/meetings/templates/meetings/_rsvp_form_response.html
@@ -1,5 +1,5 @@
 {% extends "shiny/slim.html" %}
-
+{% load crispy_forms_tags %}
 {% load i18n static %}
 
 {% block head_title %}{% trans "RSVPs" %}{% endblock %}

--- a/chipy_org/libs/custom_captcha.py
+++ b/chipy_org/libs/custom_captcha.py
@@ -1,5 +1,14 @@
-from captcha.fields import CaptchaTextInput
+from django_recaptcha.widgets import ReCaptchaV2Checkbox
 
 
-class CustomCaptchaTextInput(CaptchaTextInput):
-    template_name = "custom_captcha/widget.html"
+class CrispyReCaptchaV2Checkbox(ReCaptchaV2Checkbox):
+    """
+    appends CSS class crispy-captcha to this widget
+    the crispy-captcha css removes the border and padding
+    applied to from the recaptcha widget by crispy-forms
+    """
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs["class"] = attrs.get("class", "") + " crispy-captcha"
+        return attrs

--- a/chipy_org/settings.py
+++ b/chipy_org/settings.py
@@ -235,10 +235,10 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.forms",
     # Third party
-    "captcha",
     "django_bleach",
     "django_gravatar",
     "django_ical",
+    'django_recaptcha',
     "flatblocks",
     "gunicorn",
     "honeypot",
@@ -335,8 +335,8 @@ BLEACH_ALLOWED_PROTOCOLS = ["http", "https", "data"]
 BLEACH_ALLOWED_STYLES = ["font-family", "font-weight", "text-decoration", "font-variant"]
 BLEACH_STRIP_TAGS = True
 
-NORECAPTCHA_SITE_KEY = env_var("NORECAPTCHA_SITE_KEY")
-NORECAPTCHA_SECRET_KEY = env_var("NORECAPTCHA_SECRET_KEY")
+RECAPTCHA_PUBLIC_KEY = env_var("NORECAPTCHA_SITE_KEY")
+RECAPTCHA_PRIVATE_KEY = env_var("NORECAPTCHA_SECRET_KEY")
 
 MEETUP_API_KEY = env_var("MEETUP_API_KEY")
 
@@ -373,3 +373,7 @@ STORAGES = {
     "default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"},
     "staticfiles": {"BACKEND": "whitenoise.storage.CompressedStaticFilesStorage"},
 }
+
+SILENCED_SYSTEM_CHECKS = []
+if DEBUG:
+    SILENCED_SYSTEM_CHECKS += ['django_recaptcha.recaptcha_test_key_error']

--- a/chipy_org/static/css/shiny.css
+++ b/chipy_org/static/css/shiny.css
@@ -337,3 +337,8 @@ ul.no-bullets {
 .form-label {
   font-weight: bold;
 }
+
+.crispy-captcha {
+    border: none;
+    padding: 0px;
+}

--- a/chipy_org/urls.py
+++ b/chipy_org/urls.py
@@ -19,7 +19,6 @@ urlpatterns = [
     path("accounts/login/", django.contrib.auth.views.LoginView.as_view()),
     path("login/", TemplateView.as_view(template_name="login.html")),
     path("grappelli/", include("grappelli.urls")),
-    path("captcha/", include("captcha.urls")),
     path("meetings/", include("chipy_org.apps.meetings.urls")),
     path("groups/", include("chipy_org.apps.subgroups.urls")),
     path("announcements/", include("chipy_org.apps.announcements.urls")),

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -50,9 +50,8 @@ django==5.1.3
     #   django-extensions
     #   django-honeypot
     #   django-ical
-    #   django-ranged-response
+    #   django-recaptcha
     #   django-recurrence
-    #   django-simple-captcha
     #   django-storages
     #   django-tinymce
     #   djangorestframework
@@ -77,12 +76,10 @@ django-honeypot==1.2.1
     # via chipy_website (pyproject.toml)
 django-ical==1.9.2
     # via chipy_website (pyproject.toml)
-django-ranged-response==0.2.0
-    # via django-simple-captcha
+django-recaptcha==4.0.0
+    # via chipy_website (pyproject.toml)
 django-recurrence==1.11.1
     # via django-ical
-django-simple-captcha==0.6.0
-    # via chipy_website (pyproject.toml)
 django-storages==1.14.4
     # via chipy_website (pyproject.toml)
 django-tinymce==4.1.0
@@ -122,9 +119,7 @@ packaging==24.2
     #   gunicorn
     #   pytest
 pillow==11.0.0
-    # via
-    #   chipy_website (pyproject.toml)
-    #   django-simple-captcha
+    # via chipy_website (pyproject.toml)
 platformdirs==4.3.6
     # via virtualenv
 pluggy==1.5.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN install -d proj/ var/log/ htdocs/ htdocs/static/
 
 # Install python packages
 ADD dev-requirements.txt ${SITE_DIR}
-ARG CACHEBUST=1 
+ARG CACHEBUST=1
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip pip install -r dev-requirements.txt
 
 COPY docker/ ${SITE_DIR}docker/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "django-gravatar2",
     "django-honeypot",
     "django-ical",
-    "django-simple-captcha",
+    "django-recaptcha",
     "django-storages",
     "django-tinymce",
     "djangorestframework",

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,9 +44,8 @@ django==5.1.3
     #   django-extensions
     #   django-honeypot
     #   django-ical
-    #   django-ranged-response
+    #   django-recaptcha
     #   django-recurrence
-    #   django-simple-captcha
     #   django-storages
     #   django-tinymce
     #   djangorestframework
@@ -71,12 +70,10 @@ django-honeypot==1.2.1
     # via chipy_website (pyproject.toml)
 django-ical==1.9.2
     # via chipy_website (pyproject.toml)
-django-ranged-response==0.2.0
-    # via django-simple-captcha
+django-recaptcha==4.0.0
+    # via chipy_website (pyproject.toml)
 django-recurrence==1.11.1
     # via django-ical
-django-simple-captcha==0.6.0
-    # via chipy_website (pyproject.toml)
 django-storages==1.14.4
     # via chipy_website (pyproject.toml)
 django-tinymce==4.1.0
@@ -104,9 +101,7 @@ oauthlib==3.2.2
 packaging==24.2
     # via gunicorn
 pillow==11.0.0
-    # via
-    #   chipy_website (pyproject.toml)
-    #   django-simple-captcha
+    # via chipy_website (pyproject.toml)
 probableparsing==0.0.1
     # via probablepeople
 probablepeople==0.5.6


### PR DESCRIPTION
Typing the values for the simple captcha is a pain.  Django-recaptcha is supported again and our keys are still in the inventories.  This PR will put us back to using google's simple checkbox as a captcha.  