### PR TITLE
Fix the contact form again

### DIFF
--- a/chipy_org/apps/contact/forms.py
+++ b/chipy_org/apps/contact/forms.py
@@ -15,7 +15,7 @@ class ContactForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields["captcha"].label = False
 
-    sender = forms.CharField(max_length=256, label="From")
+    sender = forms.CharField(max_length=256, label="Name")
     email = forms.EmailField(max_length=256)
     subject = forms.CharField(max_length=256)
     message = forms.CharField(

--- a/chipy_org/apps/contact/forms.py
+++ b/chipy_org/apps/contact/forms.py
@@ -1,7 +1,5 @@
 import logging
 
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit
 from django import forms
 from django.conf import settings
 from django_recaptcha.fields import ReCaptchaField
@@ -15,8 +13,6 @@ logger = logging.getLogger(__name__)
 class ContactForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.helper = FormHelper()
-        self.helper.add_input(Submit("submit", "Send Email"))
         self.fields["captcha"].label = False
 
     sender = forms.CharField(max_length=256, label="From")

--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -1,5 +1,4 @@
 {% extends "shiny/slim.html" %}
-{% load crispy_forms_tags %}
 
 {% block page_header %}CONTACT US{% endblock %}
 
@@ -10,7 +9,7 @@
       <div class="module span6">
         <div id="contact">
           {% if user.is_authenticated %}
-            {% crispy form %}
+            {% form %}
           {% else %}
             <p>To contact the ChiPy Organizers, please log in first! Use the Blue Button above to login with either a Google or Github account. It's super quick and then you can send a message. </p>
           {% endif %}

--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -9,7 +9,11 @@
       <div class="module span6">
         <div id="contact">
           {% if user.is_authenticated %}
-            {% form %}
+            <form action="/contact/" method="post">
+              {% csrf_token %}
+              {{ form }}
+              <input type="submit" value="Send Email">
+            </form>
           {% else %}
             <p>To contact the ChiPy Organizers, please log in first! Use the Blue Button above to login with either a Google or Github account. It's super quick and then you can send a message. </p>
           {% endif %}

--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -1,4 +1,6 @@
 {% extends "shiny/slim.html" %}
+{% load crispy_forms_tags %}
+
 
 {% block page_header %}CONTACT US{% endblock %}
 
@@ -11,7 +13,7 @@
           {% if user.is_authenticated %}
             <form action="/contact/" method="post">
               {% csrf_token %}
-              {{ form }}
+              {{ form|crispy }}
               <input type="submit" value="Send Email">
             </form>
           {% else %}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -120,10 +120,6 @@ djangorestframework==3.15.2
     # via
     #   -c requirements.txt
     #   chipy_website (pyproject.toml)
-doublemetaphone==1.1
-    # via
-    #   -c requirements.txt
-    #   probablepeople
 filelock==3.16.1
     # via virtualenv
 freezegun==1.5.1
@@ -181,14 +177,6 @@ pluggy==1.5.0
     # via pytest
 pre-commit==4.0.1
     # via chipy_website (pyproject.toml)
-probableparsing==0.0.1
-    # via
-    #   -c requirements.txt
-    #   probablepeople
-probablepeople==0.5.6
-    # via
-    #   -c requirements.txt
-    #   chipy_website (pyproject.toml)
 psycopg2-binary==2.9.10
     # via
     #   -c requirements.txt
@@ -207,10 +195,6 @@ pytest==8.3.4
     #   pytest-django
 pytest-django==4.9.0
     # via chipy_website (pyproject.toml)
-python-crfsuite==0.9.11
-    # via
-    #   -c requirements.txt
-    #   probablepeople
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "gunicorn",
     "nh3",
     "pillow",
-    "probablepeople",
     "psycopg2-binary",
     "python-openid2",
     "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,8 +73,6 @@ django-tinymce==4.1.0
     # via chipy_website (pyproject.toml)
 djangorestframework==3.15.2
     # via chipy_website (pyproject.toml)
-doublemetaphone==1.1
-    # via probablepeople
 gunicorn==23.0.0
     # via chipy_website (pyproject.toml)
 icalendar==6.1.0
@@ -97,18 +95,12 @@ packaging==24.2
     # via gunicorn
 pillow==11.1.0
     # via chipy_website (pyproject.toml)
-probableparsing==0.0.1
-    # via probablepeople
-probablepeople==0.5.6
-    # via chipy_website (pyproject.toml)
 psycopg2-binary==2.9.10
     # via chipy_website (pyproject.toml)
 pycparser==2.22
     # via cffi
 pyjwt==2.10.1
     # via social-auth-core
-python-crfsuite==0.9.11
-    # via probablepeople
 python-dateutil==2.9.0.post0
     # via
     #   botocore


### PR DESCRIPTION
Fixes #577 ... I hope.

Pretty sure the Crispy Form Helper was automagically overwriting the user-submitted email with the (empty) value from the social auth user profile.

Changes:
- remove crispy.FormHelper and convert to a regular Django form
- remove unused dep that angers cython
- tested locally
- unit tests are passing 
- screenshot from logs, but others are **_strongly_** encouraged to verify:

<img width="935" height="671" alt="image" src="https://github.com/user-attachments/assets/f7adb613-64c6-4197-b9e6-732cfc9a91ff" />
