### PR TITLE
change field type and add email to body text

### DIFF
--- a/chipy_org/apps/contact/forms.py
+++ b/chipy_org/apps/contact/forms.py
@@ -16,7 +16,7 @@ class ContactForm(forms.Form):
         self.fields["captcha"].label = False
 
     sender = forms.CharField(max_length=256, label="Name")
-    email = forms.EmailField(max_length=256)
+    email = forms.CharField(max_length=256, label="Email")
     subject = forms.CharField(max_length=256)
     message = forms.CharField(
         max_length=2000,
@@ -31,9 +31,10 @@ class ContactForm(forms.Form):
         # send_email has this value set as a default, and it should not be overwritten.
         # reply_to is set as the requester's email so that when an  organizer replies
         # the reply goes to the email entered by the user in the contact form.
+        body_text = self.cleaned_data["email"] + " wrote:\n\n" + self.cleaned_data["message"]
         send_email(
             recipients=getattr(settings, "ENVELOPE_EMAIL_RECIPIENTS", []),
             subject=self.cleaned_data["subject"],
-            body=self.cleaned_data["message"],
+            body=body_text,
             reply_to=[self.cleaned_data["email"]],
         )


### PR DESCRIPTION
Trying to fix #577, once again.

Change "email" field type to CharField and concat the value to the body text, just in case.

<img width="930" height="892" alt="image" src="https://github.com/user-attachments/assets/85cc4ceb-5f06-4f7c-8e4c-e581eebfe4f5" />

<img width="930" height="491" alt="image" src="https://github.com/user-attachments/assets/57ac2035-f93f-41d6-8d76-63a394dbc665" />
