### PR TITLE
Remove 'details' link. Change 'Learn more' link to 'Learn more details'

### DIFF
--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -98,7 +98,7 @@
                     {% endif %}
 
                     {% include "shiny/_rsvp.html" with curr_meeting=next_meeting %}
-                    <p><a href="{{ next_meeting.get_absolute_url }}">details</a></p>
+                    
                 {% endif %}
         </div> <!--closes column-->
 
@@ -132,7 +132,7 @@
                 {% endif %}
                 <p>
                   {{ topic.description|nh3|truncatewords_html:80|safe }}
-                    <a href="{% url 'meeting' next_meeting.pk %}">Learn more</a>
+                    <a href="{% url 'meeting' next_meeting.pk %}">Learn more details</a>
                 </p>
             </div>
         {% endfor %}

--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -131,12 +131,12 @@
                 </div>
                 {% endif %}
                 <p>
-                  {% if topic.description|nh3|wordcount > 85 %}
-                  {{ topic.description|nh3|truncatewords_html:80|safe }}
+                {% if topic.description|nh3|wordcount > 85 %}
+                    {{ topic.description|nh3|truncatewords_html:80|safe }}
                     <a href="{% url 'meeting' next_meeting.pk %}">Learn more details</a>
-                  {% else %}
+                {% else %}
                     {{ topic.description|nh3|safe }}
-                  {% endif %}  
+                {% endif %}  
                 </p>
             </div>
         {% endfor %}

--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -131,7 +131,7 @@
                 </div>
                 {% endif %}
                 <p>
-                {% if topic.description|nh3|wordcount > 85 %}
+                {% if topic.description|nh3|wordcount > 90 %}
                     {{ topic.description|nh3|truncatewords_html:80|safe }}
                     <a href="{% url 'meeting' next_meeting.pk %}">Learn more details</a>
                 {% else %}

--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -133,7 +133,7 @@
                 <p>
                 {% if topic.description|nh3|wordcount > 90 %}
                     {{ topic.description|nh3|truncatewords_html:80|safe }}
-                    <a href="{% url 'meeting' next_meeting.pk %}">Learn more details</a>
+                    <a href="{% url 'meeting' next_meeting.pk %}">Learn more</a>
                 {% else %}
                     {{ topic.description|nh3|safe }}
                 {% endif %}  

--- a/chipy_org/apps/main/templates/main/homepage.html
+++ b/chipy_org/apps/main/templates/main/homepage.html
@@ -131,8 +131,12 @@
                 </div>
                 {% endif %}
                 <p>
+                  {% if topic.description|nh3|wordcount > 85 %}
                   {{ topic.description|nh3|truncatewords_html:80|safe }}
                     <a href="{% url 'meeting' next_meeting.pk %}">Learn more details</a>
+                  {% else %}
+                    {{ topic.description|nh3|safe }}
+                  {% endif %}  
                 </p>
             </div>
         {% endfor %}


### PR DESCRIPTION
<img width="1035" height="762" alt="Screenshot from 2026-01-28 21-57-59" src="https://github.com/user-attachments/assets/cff48842-43ff-4ab5-a94d-b814cea9a319" />

What the results of the PR looks like.

Fixes issue #576 